### PR TITLE
Add lgpio and rpi_ws281x to backend requirements

### DIFF
--- a/servers/robot-controller-backend/requirements.txt
+++ b/servers/robot-controller-backend/requirements.txt
@@ -2,7 +2,9 @@
 
 # Core dependencies
 Adafruit-PCA9685==1.0.1
-RPi.GPIO==0.7.0
+RPi.GPIO==0.7.0  # Legacy Pi 4 support
+lgpio  # GPIO control on Pi 5
+rpi_ws281x  # WS281x LED strip support
 smbus2==0.4.1  # Added for I2C communication with ADC chips
 
 # Flask and WebSocket dependencies for the video server


### PR DESCRIPTION
## Summary
- add dependencies for Pi5 GPIO and LED strip
- preserve RPi.GPIO with comment for legacy Pi4

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'websocket')*

------
https://chatgpt.com/codex/tasks/task_e_68422dfb7d9c83329b35d21fbb10a13c