### PR TITLE
Switch remaining GPIO scripts to lgpio

### DIFF
--- a/ros/scripts/line_tracking_publisher.py
+++ b/ros/scripts/line_tracking_publisher.py
@@ -12,7 +12,7 @@ Functions:
 
 Dependencies:
 - ROS: rospy, std_msgs
-- RPi.GPIO: GPIO
+- lgpio
 
 Usage:
 - Run this script to start the line tracking publisher node.
@@ -21,18 +21,18 @@ Usage:
 #!/usr/bin/env python
 import rospy
 from std_msgs.msg import Int32MultiArray
-import RPi.GPIO as GPIO
+import lgpio
 
-GPIO.setmode(GPIO.BCM)
 IR01 = 14
 IR02 = 15
 IR03 = 18
-GPIO.setup(IR01, GPIO.IN)
-GPIO.setup(IR02, GPIO.IN)
-GPIO.setup(IR03, GPIO.IN)
+h = lgpio.gpiochip_open(0)
+lgpio.gpio_claim_input(h, IR01)
+lgpio.gpio_claim_input(h, IR02)
+lgpio.gpio_claim_input(h, IR03)
 
 def read_line_sensors():
-    return [GPIO.input(IR01), GPIO.input(IR02), GPIO.input(IR03)]
+    return [lgpio.gpio_read(h, IR01), lgpio.gpio_read(h, IR02), lgpio.gpio_read(h, IR03)]
 
 def publish_line_tracking():
     pub = rospy.Publisher('line_tracking/data', Int32MultiArray, queue_size=10)
@@ -50,4 +50,6 @@ if __name__ == '__main__':
     try:
         publish_line_tracking()
     except rospy.ROSInterruptException:
-        GPIO.cleanup()
+        pass
+    finally:
+        lgpio.gpiochip_close(h)

--- a/servers/robot-controller-backend/commands/buzzer_control.py
+++ b/servers/robot-controller-backend/commands/buzzer_control.py
@@ -1,23 +1,29 @@
 # File: /Omega-Code/servers/robot-controller-backend/commands/buzzer_control.py
 
-import RPi.GPIO as GPIO
+import lgpio
 import sys
 import time
 
 # Configure GPIO settings
-GPIO.setwarnings(False)
 Buzzer_Pin = 17  # Define the GPIO pin connected to the buzzer
-GPIO.setmode(GPIO.BCM)
-GPIO.setup(Buzzer_Pin, GPIO.OUT)
 
 class Buzzer:
+    def __init__(self):
+        """Initialize the buzzer GPIO using lgpio."""
+        self.h = lgpio.gpiochip_open(0)
+        lgpio.gpio_claim_output(self.h, Buzzer_Pin, 0)
+
     def activate(self):
         """Activate the buzzer."""
-        GPIO.output(Buzzer_Pin, True)
+        lgpio.gpio_write(self.h, Buzzer_Pin, 1)
 
     def deactivate(self):
         """Deactivate the buzzer."""
-        GPIO.output(Buzzer_Pin, False)
+        lgpio.gpio_write(self.h, Buzzer_Pin, 0)
+
+    def close(self):
+        """Release the GPIO handle."""
+        lgpio.gpiochip_close(self.h)
 
 
 if __name__ == "__main__":
@@ -38,4 +44,4 @@ if __name__ == "__main__":
     except Exception as e:
         print(f"Error: {e}")
     finally:
-        GPIO.cleanup()
+        buzzer.close()

--- a/servers/robot-controller-backend/gpio/gpio_simulator.py
+++ b/servers/robot-controller-backend/gpio/gpio_simulator.py
@@ -1,24 +1,27 @@
 # File: /Omega-Code/servers/robot-controller-backend/gpio/gpio_simulator.py
-
 """
-This script simulates GPIO actions using the RPi.GPIO library.
+This script simulates GPIO actions using the lgpio library.
 It provides basic GPIO operations like setting pin mode, outputting values, and cleanup.
 """
 
-import RPi.GPIO as GPIO
-import time
+import lgpio
 import sys
+import time
 
 # Setup pin and state based on arguments
 pin = int(sys.argv[1])
-state = sys.argv[2]
+state = sys.argv[2].upper()
 
-GPIO.setmode(GPIO.BOARD)
-GPIO.setup(pin, GPIO.OUT)
+h = lgpio.gpiochip_open(0)
+lgpio.gpio_claim_output(h, pin, 0)
 
 if state == 'HIGH':
-    GPIO.output(pin, GPIO.HIGH)
+    lgpio.gpio_write(h, pin, 1)
 elif state == 'LOW':
-    GPIO.output(pin, GPIO.LOW)
+    lgpio.gpio_write(h, pin, 0)
 else:
     print("Invalid state")
+
+# Brief delay to allow observation when testing
+time.sleep(0.1)
+lgpio.gpiochip_close(h)


### PR DESCRIPTION
## Summary
- migrate buzzer control to `lgpio`
- update line tracking controller to use `lgpio`
- replace RPi.GPIO in gpio simulator
- convert ROS line tracking publisher to `lgpio`
- switch ROS ultrasonic publisher to `lgpio`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for several optional deps)*

------
https://chatgpt.com/codex/tasks/task_e_68422f9febc48332b17418a999ee0808