### PR TITLE
Fix LED control imports and package init files

### DIFF
--- a/servers/robot-controller-backend/controllers/__init__.py
+++ b/servers/robot-controller-backend/controllers/__init__.py
@@ -1,0 +1,2 @@
+"""Controller package."""
+

--- a/servers/robot-controller-backend/controllers/lighting/__init__.py
+++ b/servers/robot-controller-backend/controllers/lighting/__init__.py
@@ -1,0 +1,2 @@
+"""Lighting controllers."""
+

--- a/servers/robot-controller-backend/utils/__init__.py
+++ b/servers/robot-controller-backend/utils/__init__.py
@@ -1,0 +1,2 @@
+"""Utility modules for the robot controller backend."""
+

--- a/servers/robot-controller-backend/utils/led_control.py
+++ b/servers/robot-controller-backend/utils/led_control.py
@@ -1,0 +1,11 @@
+from controllers.lighting.led_control import LedControl
+
+class Led(LedControl):
+    """Backward-compatible wrapper around :class:`LedControl`."""
+
+    # Alias methods to maintain legacy API
+    colorWipe = LedControl.color_wipe
+    theaterChase = LedControl.theater_chase
+    setLed = LedControl.set_led
+    LED_TYPR = LedControl._convert_color
+


### PR DESCRIPTION
## Summary
- restore `utils/led_control` to wrap the new lighting controller
- add `__init__.py` files so modules can be imported as packages

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'websocket')*

------
https://chatgpt.com/codex/tasks/task_e_68423ce5b82c8332ab00f7ce64683dd5