### PR TITLE
Fix CI workflow syntax

### DIFF
--- a/servers/robot-controller-backend/.github/workflows/ci.yml
+++ b/servers/robot-controller-backend/.github/workflows/ci.yml
@@ -33,5 +33,3 @@ jobs:
           source venv/bin/activate
           export PYTHONPATH=$(pwd)
           pytest
-
-          


### PR DESCRIPTION
## Summary
- clean up robot-controller-backend CI workflow

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rospy')*

------
https://chatgpt.com/codex/tasks/task_e_6845102fe16c8332a70a57b5af3df9c8