### PR TITLE
Update README structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,12 @@ Omega-Code is a comprehensive project aimed at developing a fully-featured robot
 
 The project is organized into several directories:
 
-- **config**: Contains configuration files necessary for the project.
+- **config** (removed): Configuration is now handled through environment
+  variables and `.env` files such as `.env.example` in the repository root.
 - **scripts**: Contains shell scripts for connecting to a hotspot.
 - **servers**: Contains the backend server code for handling robot commands.
 - **ui**: Contains the frontend user interface code for the robot controller.
 - **ros**: Contains ROS nodes and scripts for various functionalities including path planning, sensor fusion, and autonomous driving.
-- **machine_learning**: Contains machine learning models and scripts for robot navigation.
 
 ## Backend Server
 


### PR DESCRIPTION
## Summary
- note the config directory was removed and replaced by `.env` files
- clean up the project structure list

## Testing
- `go test ./...` *(fails: no module provides periph.io packages)*
- `pytest -q` *(fails: multiple module import errors)*

------
https://chatgpt.com/codex/tasks/task_e_684510c9c904833287fbba5943f476e2