### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,11 +13,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: '3.10'
 
@@ -26,11 +24,10 @@ jobs:
           python -m venv venv
           source venv/bin/activate
           pip install --upgrade pip
-          pip install -r requirements.txt
+          pip install -r servers/robot-controller-backend/requirements.txt
 
       - name: Run tests
         run: |
           source venv/bin/activate
-          export PYTHONPATH=$(pwd)
-          pytest
-
+          export PYTHONPATH=$(pwd)/servers/robot-controller-backend
+          pytest servers/robot-controller-backend


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow to run tests
- clean up the backend CI workflow format

## Testing
- `pytest servers/robot-controller-backend -q` *(fails: ModuleNotFoundError: No module named 'cv2')*

------
https://chatgpt.com/codex/tasks/task_e_6845038696a483328ac227d123ca4d2a