### PR TITLE
Add CI workflow and trim trailing newline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,11 +13,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: '3.10'
 
@@ -26,10 +24,10 @@ jobs:
           python -m venv venv
           source venv/bin/activate
           pip install --upgrade pip
-          pip install -r requirements.txt
+          pip install -r servers/robot-controller-backend/requirements.txt
 
       - name: Run tests
         run: |
           source venv/bin/activate
-          export PYTHONPATH=$(pwd)
-          pytest
+          export PYTHONPATH=$(pwd)/servers/robot-controller-backend
+          pytest servers/robot-controller-backend


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow at repo root for backend tests
- remove redundant newline from backend CI file

## Testing
- `pip install -r servers/robot-controller-backend/requirements.txt` *(fails: RPi.GPIO wheel build error)*
- `pytest servers/robot-controller-backend/tests` *(fails: module import errors)*


------
https://chatgpt.com/codex/tasks/task_e_684514deb84483328a811898bd060b66