### PR TITLE
Fix README paths and usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ The repository includes a comprehensive set of tests organized into unit tests, 
 
 ### Usage
 
-Open a web browser and navigate to `https://localhost:3000` to access the robot controller interface. Use the provided controls to send commands to the robot.
+Open a web browser and navigate to `http://localhost:3000` to access the robot controller interface. If you have configured HTTPS, use `https://localhost:3000` instead. Use the provided controls to send commands to the robot.
 
 ## Acknowledgements
 
@@ -261,8 +261,6 @@ Special thanks to Freenove for providing the **Freenove 4WD Smart Car Kit for Ra
 
 > A 4WD smart car kit for Raspberry Pi.
 
-![Freenove](Picture/icon.png)
-![Freenove](Picture/icon1.png)
 
 #### Download
 


### PR DESCRIPTION
## Summary
- remove outdated Freenove picture links
- clarify URL in Usage section

## Testing
- `npm test --silent` *(fails: jest not found)*
- `pytest -q` *(fails: ModuleNotFoundError: rospy)*

------
https://chatgpt.com/codex/tasks/task_e_684515a247e8833290357965c0a17778