### PR TITLE
Update README project structure list

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,10 @@ Omega-Code is a comprehensive project aimed at developing a fully-featured robot
 
 The project is organized into several directories:
 
-- **config**: Contains configuration files necessary for the project.
 - **scripts**: Contains shell scripts for connecting to a hotspot.
 - **servers**: Contains the backend server code for handling robot commands.
 - **ui**: Contains the frontend user interface code for the robot controller.
 - **ros**: Contains ROS nodes and scripts for various functionalities including path planning, sensor fusion, and autonomous driving.
-- **machine_learning**: Contains machine learning models and scripts for robot navigation.
 
 ## Backend Server
 


### PR DESCRIPTION
## Summary
- remove config and machine_learning entries from project structure list

## Testing
- `pytest -q` *(fails: ImportError: No module named 'rospy')*
- `npm test` in `ui/robot-controller-ui` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68451880ca908332b01b758999635ba4