### PR TITLE
Update backend run instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The backend server, written in Go, handles incoming HTTP and WebSocket requests 
 ### Main Application
 
 - **Main Application (Go)**: `main.go` - Entry point of the backend server.
-- **Main Application (Python)**: `main.py` - Entry point of the Python backend server.
+- **Combined Application (Go)**: `main_combined.go` - Starts the Go server along with the Python video server and ROS nodes.
 
 ### Line Tracking
 

--- a/servers/robot-controller-backend/Readme.md
+++ b/servers/robot-controller-backend/Readme.md
@@ -21,7 +21,6 @@ The project is organized into several directories and files:
 - **venv**: Python virtual environment for dependencies.
 - **main.go**: Entry point of the backend server (Go).
 - **main_combined.go**: Starts the server along with the Python video server and ROS nodes.
-- **main.py**: Entry point of the backend server (Python).
 - **server.csr**: Certificate Signing Request file.
 - **server.log**: Log file for server activities.
 - **go.mod**: Go module definitions.
@@ -99,15 +98,15 @@ The project is organized into several directories and files:
 
 ### Running the Project
 
-1. Start the backend server (Go):
+1. Start the backend server with Go:
 
    ```bash
    go run main.go
    ```
-2. Start the backend server (Python):
+   Or run the combined server:
 
    ```bash
-   python main.py
+   go run main_combined.go
    ```
 
 ### Usage


### PR DESCRIPTION
## Summary
- document `main_combined.go` instead of Python `main.py`
- remove `main.py` references in backend README
- clarify backend run commands

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*
- `go test ./...` *(fails: found packages core and main)*

------
https://chatgpt.com/codex/tasks/task_e_68451eaa5cfc8332abb5c1b092f2d6ac