### PR TITLE
Add Pi 5 lighting compatibility

### DIFF
--- a/servers/robot-controller-backend/controllers/lighting/led_control.py
+++ b/servers/robot-controller-backend/controllers/lighting/led_control.py
@@ -14,7 +14,32 @@ Key functionalities:
 
 import sys
 import time
-from rpi_ws281x import *
+
+try:
+    from rpi_ws281x import PixelStrip, Color
+except Exception:  # pragma: no cover - handle missing library gracefully
+    try:
+        from rpi_ws281x import Adafruit_NeoPixel as PixelStrip, Color
+    except Exception:
+        # Provide a minimal stub for environments without rpi_ws281x
+        class PixelStrip:
+            def __init__(self, num, pin, freq_hz, dma, invert, brightness, channel):
+                self._num = num
+
+            def begin(self):
+                pass
+
+            def numPixels(self):
+                return self._num
+
+            def setPixelColor(self, i, color):
+                pass
+
+            def show(self):
+                pass
+
+        def Color(r, g, b):
+            return (r << 16) | (g << 8) | b
 
 # LED strip configuration constants
 LED_COUNT = 8            # Number of LED pixels
@@ -35,8 +60,14 @@ class LedControl:
         """
         try:
             self.ORDER = "RGB"  # Default color order
-            self.strip = Adafruit_NeoPixel(
-                LED_COUNT, LED_PIN, LED_FREQ_HZ, LED_DMA, LED_INVERT, LED_BRIGHTNESS, LED_CHANNEL
+            self.strip = PixelStrip(
+                LED_COUNT,
+                LED_PIN,
+                LED_FREQ_HZ,
+                LED_DMA,
+                LED_INVERT,
+                LED_BRIGHTNESS,
+                LED_CHANNEL,
             )
             self.strip.begin()  # Initialize the LED strip
         except Exception as e:

--- a/servers/robot-controller-backend/tests/unit/controllers_led_control_test.py
+++ b/servers/robot-controller-backend/tests/unit/controllers_led_control_test.py
@@ -1,0 +1,28 @@
+import unittest
+from unittest.mock import patch, MagicMock
+
+from controllers.lighting import led_control as lc
+
+class TestControllersLedControl(unittest.TestCase):
+    @patch('controllers.lighting.led_control.PixelStrip')
+    def test_init_calls_pixel_strip(self, MockStrip):
+        instance = MockStrip.return_value
+        led = lc.LedControl()
+        MockStrip.assert_called_with(
+            lc.LED_COUNT,
+            lc.LED_PIN,
+            lc.LED_FREQ_HZ,
+            lc.LED_DMA,
+            lc.LED_INVERT,
+            lc.LED_BRIGHTNESS,
+            lc.LED_CHANNEL,
+        )
+        instance.begin.assert_called_once()
+
+    def test_convert_color_valid(self):
+        led = lc.LedControl()
+        result = led._convert_color('RGB', 0x112233)
+        self.assertIsInstance(result, int)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- make lighting controller fallback to PixelStrip/Adafruit_NeoPixel
- include stub implementations when `rpi_ws281x` isn't installed
- test LED initialization and color conversion

## Testing
- `pytest servers/robot-controller-backend/tests/unit/controllers_led_control_test.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6845ea93ee5083329cdee992c04d473d