### PR TITLE
Improve LED stub cleanup

### DIFF
--- a/servers/robot-controller-backend/controllers/lighting/basic_led_test.py
+++ b/servers/robot-controller-backend/controllers/lighting/basic_led_test.py
@@ -1,0 +1,48 @@
+"""Basic LED functionality test script."""
+
+import time
+
+import os
+import sys
+
+if __package__ in (None, ""):
+    # Support running as a standalone script
+    sys.path.append(os.path.dirname(__file__))
+    from led_control import LedControl
+else:  # pragma: no cover - imported as package
+    from .led_control import LedControl
+
+
+def run_test():
+    """Run a simple sequence of LED patterns to verify functionality."""
+    led = LedControl()
+
+    print("Starting LED functionality test. Press Ctrl+C to exit.")
+
+    # Cycle through primary colors with a color wipe effect
+    colors = [0xFF0000, 0x00FF00, 0x0000FF]
+    for color in colors:
+        print(f"Color wipe: {color:#06x}")
+        led.color_wipe(color, wait_ms=100)
+        time.sleep(0.5)
+
+    # Theater chase effect with white color
+    print("Theater chase")
+    led.theater_chase(0xFFFFFF, wait_ms=50, iterations=5)
+
+    # Rainbow cycle
+    print("Rainbow")
+    led.rainbow(wait_ms=20, iterations=1)
+
+    print("LED test complete.")
+    # Explicitly delete the LED controller to ensure any underlying resources
+    # are cleaned up before exiting. This helps avoid segfaults on some
+    # platforms when the rpi_ws281x library fails to initialize.
+    del led
+
+
+if __name__ == "__main__":
+    try:
+        run_test()
+    except KeyboardInterrupt:
+        print("Test interrupted by user.")

--- a/servers/robot-controller-backend/tests/unit/basic_led_test_script_test.py
+++ b/servers/robot-controller-backend/tests/unit/basic_led_test_script_test.py
@@ -1,0 +1,27 @@
+import unittest
+from unittest.mock import patch, call
+
+from controllers.lighting import basic_led_test
+
+
+class TestBasicLedTestScript(unittest.TestCase):
+    @patch("controllers.lighting.basic_led_test.time.sleep", return_value=None)
+    @patch("controllers.lighting.basic_led_test.LedControl")
+    def test_run_test_invokes_patterns(self, MockLedControl, _):
+        instance = MockLedControl.return_value
+        basic_led_test.run_test()
+
+        self.assertEqual(instance.color_wipe.call_count, 3)
+        instance.color_wipe.assert_has_calls(
+            [
+                call(0xFF0000, wait_ms=100),
+                call(0x00FF00, wait_ms=100),
+                call(0x0000FF, wait_ms=100),
+            ]
+        )
+        instance.theater_chase.assert_called_once_with(0xFFFFFF, wait_ms=50, iterations=5)
+        instance.rainbow.assert_called_once_with(wait_ms=20, iterations=1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/servers/robot-controller-backend/tests/unit/controllers_led_control_test.py
+++ b/servers/robot-controller-backend/tests/unit/controllers_led_control_test.py
@@ -1,0 +1,35 @@
+import unittest
+from unittest.mock import patch, MagicMock
+
+from controllers.lighting import led_control as lc
+
+class TestControllersLedControl(unittest.TestCase):
+    @patch('controllers.lighting.led_control.PixelStrip')
+    def test_init_calls_pixel_strip(self, MockStrip):
+        instance = MockStrip.return_value
+        led = lc.LedControl()
+        MockStrip.assert_called_with(
+            lc.LED_COUNT,
+            lc.LED_PIN,
+            lc.LED_FREQ_HZ,
+            lc.LED_DMA,
+            lc.LED_INVERT,
+            lc.LED_BRIGHTNESS,
+            lc.LED_CHANNEL,
+        )
+        instance.begin.assert_called_once()
+
+    @patch('controllers.lighting.led_control.PixelStrip')
+    def test_init_falls_back_to_stub_on_error(self, MockStrip):
+        instance = MockStrip.return_value
+        instance.begin.side_effect = RuntimeError('boom')
+        led = lc.LedControl()
+        self.assertTrue(isinstance(led.strip, lc.StubPixelStrip))
+
+    def test_convert_color_valid(self):
+        led = lc.LedControl()
+        result = led._convert_color('RGB', 0x112233)
+        self.assertIsInstance(result, int)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- avoid holding a partially initialized `PixelStrip` when fallback is used
- explicitly delete LED controller at the end of the basic test script

## Testing
- `PYTHONPATH=servers/robot-controller-backend pytest servers/robot-controller-backend/tests/unit/controllers_led_control_test.py servers/robot-controller-backend/tests/unit/basic_led_test_script_test.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6845ea93ee5083329cdee992c04d473d