### PR TITLE
Add stub fallback for LED strip

### DIFF
--- a/servers/robot-controller-backend/controllers/lighting/__init__.py
+++ b/servers/robot-controller-backend/controllers/lighting/__init__.py
@@ -1,2 +1,6 @@
 """Lighting controllers."""
 
+from .led_control import LedControl, StubPixelStrip
+
+__all__ = ["LedControl", "StubPixelStrip"]
+

--- a/servers/robot-controller-backend/controllers/lighting/basic_led_test.py
+++ b/servers/robot-controller-backend/controllers/lighting/basic_led_test.py
@@ -1,0 +1,44 @@
+"""Basic LED functionality test script."""
+
+import time
+
+import os
+import sys
+
+if __package__ in (None, ""):
+    # Support running as a standalone script
+    sys.path.append(os.path.dirname(__file__))
+    from led_control import LedControl
+else:  # pragma: no cover - imported as package
+    from .led_control import LedControl
+
+
+def run_test():
+    """Run a simple sequence of LED patterns to verify functionality."""
+    led = LedControl()
+
+    print("Starting LED functionality test. Press Ctrl+C to exit.")
+
+    # Cycle through primary colors with a color wipe effect
+    colors = [0xFF0000, 0x00FF00, 0x0000FF]
+    for color in colors:
+        print(f"Color wipe: {color:#06x}")
+        led.color_wipe(color, wait_ms=100)
+        time.sleep(0.5)
+
+    # Theater chase effect with white color
+    print("Theater chase")
+    led.theater_chase(0xFFFFFF, wait_ms=50, iterations=5)
+
+    # Rainbow cycle
+    print("Rainbow")
+    led.rainbow(wait_ms=20, iterations=1)
+
+    print("LED test complete.")
+
+
+if __name__ == "__main__":
+    try:
+        run_test()
+    except KeyboardInterrupt:
+        print("Test interrupted by user.")

--- a/servers/robot-controller-backend/controllers/lighting/led_control.py
+++ b/servers/robot-controller-backend/controllers/lighting/led_control.py
@@ -14,7 +14,40 @@ Key functionalities:
 
 import sys
 import time
-from rpi_ws281x import *
+
+__all__ = ["LedControl", "StubPixelStrip"]
+
+
+class StubPixelStrip:
+    """Fallback LED strip that performs no hardware operations."""
+
+    def __init__(self, num, pin, freq_hz, dma, invert, brightness, channel):
+        self._num = num
+        self.is_stub = True
+
+    def begin(self):
+        pass
+
+    def numPixels(self):
+        return self._num
+
+    def setPixelColor(self, i, color):
+        pass
+
+    def show(self):
+        pass
+
+
+try:
+    from rpi_ws281x import PixelStrip, Color
+except Exception:  # pragma: no cover - handle missing library gracefully
+    try:
+        from rpi_ws281x import Adafruit_NeoPixel as PixelStrip, Color
+    except Exception:
+        PixelStrip = StubPixelStrip
+
+        def Color(r, g, b):
+            return (r << 16) | (g << 8) | b
 
 # LED strip configuration constants
 LED_COUNT = 8            # Number of LED pixels
@@ -35,12 +68,28 @@ class LedControl:
         """
         try:
             self.ORDER = "RGB"  # Default color order
-            self.strip = Adafruit_NeoPixel(
-                LED_COUNT, LED_PIN, LED_FREQ_HZ, LED_DMA, LED_INVERT, LED_BRIGHTNESS, LED_CHANNEL
+            self.strip = PixelStrip(
+                LED_COUNT,
+                LED_PIN,
+                LED_FREQ_HZ,
+                LED_DMA,
+                LED_INVERT,
+                LED_BRIGHTNESS,
+                LED_CHANNEL,
             )
             self.strip.begin()  # Initialize the LED strip
         except Exception as e:
-            raise RuntimeError(f"Failed to initialize LED strip: {e}")
+            print(f"Warning: Failed to initialize LED strip: {e}")
+            self.strip = StubPixelStrip(
+                LED_COUNT,
+                LED_PIN,
+                LED_FREQ_HZ,
+                LED_DMA,
+                LED_INVERT,
+                LED_BRIGHTNESS,
+                LED_CHANNEL,
+            )
+            print("Using stub LED strip; no hardware output will occur")
 
     def _convert_color(self, order, R_G_B):
         """

--- a/servers/robot-controller-backend/tests/unit/basic_led_test_script_test.py
+++ b/servers/robot-controller-backend/tests/unit/basic_led_test_script_test.py
@@ -1,0 +1,27 @@
+import unittest
+from unittest.mock import patch, call
+
+from controllers.lighting import basic_led_test
+
+
+class TestBasicLedTestScript(unittest.TestCase):
+    @patch("controllers.lighting.basic_led_test.time.sleep", return_value=None)
+    @patch("controllers.lighting.basic_led_test.LedControl")
+    def test_run_test_invokes_patterns(self, MockLedControl, _):
+        instance = MockLedControl.return_value
+        basic_led_test.run_test()
+
+        self.assertEqual(instance.color_wipe.call_count, 3)
+        instance.color_wipe.assert_has_calls(
+            [
+                call(0xFF0000, wait_ms=100),
+                call(0x00FF00, wait_ms=100),
+                call(0x0000FF, wait_ms=100),
+            ]
+        )
+        instance.theater_chase.assert_called_once_with(0xFFFFFF, wait_ms=50, iterations=5)
+        instance.rainbow.assert_called_once_with(wait_ms=20, iterations=1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/servers/robot-controller-backend/tests/unit/controllers_led_control_test.py
+++ b/servers/robot-controller-backend/tests/unit/controllers_led_control_test.py
@@ -1,0 +1,35 @@
+import unittest
+from unittest.mock import patch, MagicMock
+
+from controllers.lighting import led_control as lc
+
+class TestControllersLedControl(unittest.TestCase):
+    @patch('controllers.lighting.led_control.PixelStrip')
+    def test_init_calls_pixel_strip(self, MockStrip):
+        instance = MockStrip.return_value
+        led = lc.LedControl()
+        MockStrip.assert_called_with(
+            lc.LED_COUNT,
+            lc.LED_PIN,
+            lc.LED_FREQ_HZ,
+            lc.LED_DMA,
+            lc.LED_INVERT,
+            lc.LED_BRIGHTNESS,
+            lc.LED_CHANNEL,
+        )
+        instance.begin.assert_called_once()
+
+    @patch('controllers.lighting.led_control.PixelStrip')
+    def test_init_falls_back_to_stub_on_error(self, MockStrip):
+        instance = MockStrip.return_value
+        instance.begin.side_effect = RuntimeError('boom')
+        led = lc.LedControl()
+        self.assertTrue(isinstance(led.strip, lc.StubPixelStrip))
+
+    def test_convert_color_valid(self):
+        led = lc.LedControl()
+        result = led._convert_color('RGB', 0x112233)
+        self.assertIsInstance(result, int)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- provide an explicit export list for `led_control`
- print a notice when falling back to the stub LED strip
- re-export `LedControl` and `StubPixelStrip` from the package

## Testing
- `PYTHONPATH=servers/robot-controller-backend pytest servers/robot-controller-backend/tests/unit/controllers_led_control_test.py servers/robot-controller-backend/tests/unit/basic_led_test_script_test.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6845ea93ee5083329cdee992c04d473d