### PR TITLE
Fix LED initialization order in LedControl

### DIFF
--- a/servers/robot-controller-backend/controllers/lighting/led_control.py
+++ b/servers/robot-controller-backend/controllers/lighting/led_control.py
@@ -88,9 +88,6 @@ class LedControl:
         """
         self.ORDER = "RGB"  # Default color order
         try:
-           
-
-            self.ORDER = "RGB"  # Default color order
             self.strip = PixelStrip(
                 LED_COUNT,
                 LED_PIN,


### PR DESCRIPTION
## Summary
- remove duplicate color order assignment in `LedControl.__init__`

## Testing
- `pytest -q` *(fails: No module named 'rospy')*

------
https://chatgpt.com/codex/tasks/task_e_684608f66fcc8332867209f09d259b0d