### PR TITLE
Fix LED constant name

### DIFF
--- a/servers/robot-controller-backend/utils/led_control.py
+++ b/servers/robot-controller-backend/utils/led_control.py
@@ -7,5 +7,6 @@ class Led(LedControl):
     colorWipe = LedControl.color_wipe
     theaterChase = LedControl.theater_chase
     setLed = LedControl.set_led
-    LED_TYPR = LedControl._convert_color
+    # Preserve legacy attribute name for compatibility
+    LED_TYPE = LedControl._convert_color
 


### PR DESCRIPTION
## Summary
- rename incorrect LED constant

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rospy')*

------
https://chatgpt.com/codex/tasks/task_e_68460908863c833290b4c2f68c6dc2ec