### PR TITLE
Fix LED strip init in controller

### DIFF
--- a/servers/robot-controller-backend/controllers/lighting/led_control.py
+++ b/servers/robot-controller-backend/controllers/lighting/led_control.py
@@ -91,7 +91,7 @@ class LedControl:
            
 
             self.ORDER = "RGB"  # Default color order
-            self.strip = PixelStrip(
+            strip = PixelStrip(
                 LED_COUNT,
                 LED_PIN,
                 LED_FREQ_HZ,


### PR DESCRIPTION
## Summary
- fix `PixelStrip` variable assignment in `LedControl` to avoid undefined name

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rospy')*

------
https://chatgpt.com/codex/tasks/task_e_684608f4140c8332aff34164b8bf3070