### PR TITLE
Update scripts to use root paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,8 +235,15 @@ The repository includes a comprehensive set of tests organized into unit tests, 
    Create a `.env` file in the `servers/robot-controller-backend` directory with the following variables:
    ```env
    CERT_PATH=/path/to/cert.pem
-   KEY_PATH=/path/to/key.pem
-   ```
+  KEY_PATH=/path/to/key.pem
+  ```
+
+### Additional Environment Variables
+
+The helper scripts in `scripts/` and in the backend support an optional
+`OMEGA_CODE_ROOT` variable. Set this to the absolute path of the repository if
+the scripts cannot automatically determine it. You can also override the path to
+the backend `.env` file with the `ENV_FILE` variable when running these scripts.
 
 ### Running the Project
 

--- a/scripts/connect_hotspot_v1.sh
+++ b/scripts/connect_hotspot_v1.sh
@@ -6,8 +6,17 @@
 # Environment variables for the iPhone SSID, iPhone password, Tailscale IP, 
 # and Raspberry Pi user should be defined in a .env file.
 
-# Load environment variables from .env file
-export $(grep -v '^#' config/.env | xargs)
+# Determine the project root. Allow override via OMEGA_CODE_ROOT
+ROOT_DIR="${OMEGA_CODE_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
+
+# Load environment variables from the project's .env file
+ENV_FILE="$ROOT_DIR/config/.env"
+if [ -f "$ENV_FILE" ]; then
+    export $(grep -v '^#' "$ENV_FILE" | xargs)
+else
+    echo "Environment file not found: $ENV_FILE" >&2
+    exit 1
+fi
 
 # Function to connect to iPhone hotspot
 connect_to_hotspot() {

--- a/scripts/connect_hotspot_v2.sh
+++ b/scripts/connect_hotspot_v2.sh
@@ -5,8 +5,17 @@
 # and SSHs into the Raspberry Pi using Tailscale IP. It dynamically
 # adjusts settings based on the hostname of the machine (Laptop1-hostname or Laptop2-hostname).
 
+# Determine project root. Allow override via OMEGA_CODE_ROOT
+ROOT_DIR="${OMEGA_CODE_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
+
 # Load environment variables from the specified .env file
-source config/.env.script2
+ENV_FILE="${ENV_FILE:-$ROOT_DIR/config/.env.script2}"
+if [ -f "$ENV_FILE" ]; then
+    source "$ENV_FILE"
+else
+    echo "Environment file not found: $ENV_FILE" >&2
+    exit 1
+fi
 
 # Get the hostname of the current machine
 HOSTNAME=$(hostname)

--- a/scripts/connect_pan.sh
+++ b/scripts/connect_pan.sh
@@ -17,8 +17,11 @@
 # - The MacBook must be paired with the iPhone via Bluetooth.
 # - The .env file must contain the iPhone’s Bluetooth MAC address.
 
-# Define the absolute path to the .env file
-ENV_FILE="/Users/abel_elreaper/Desktop/Omega-Code/servers/robot-controller-backend/.env"
+# Determine project root. Allow override via OMEGA_CODE_ROOT
+ROOT_DIR="${OMEGA_CODE_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
+
+# Path to the .env file (can be overridden with ENV_FILE)
+ENV_FILE="${ENV_FILE:-$ROOT_DIR/servers/robot-controller-backend/.env}"
 
 # Load environment variables from .env file
 if [ -f "$ENV_FILE" ]; then

--- a/scripts/connect_robot_bluetooth.sh
+++ b/scripts/connect_robot_bluetooth.sh
@@ -5,8 +5,11 @@
 # This script connects both your **MacBook and Raspberry Pi (Omega1)** to the iPhone's Personal Hotspot via Bluetooth PAN.
 # Since macOS does not have `bt-network`, it uses `blueutil` instead.
 
-# Define the absolute path to the .env file
-ENV_FILE="/Users/abel_elreaper/Desktop/Omega-Code/servers/robot-controller-backend/.env"
+# Determine project root. Allow override via OMEGA_CODE_ROOT
+ROOT_DIR="${OMEGA_CODE_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
+
+# Path to the .env file (can be overridden with ENV_FILE)
+ENV_FILE="${ENV_FILE:-$ROOT_DIR/servers/robot-controller-backend/.env}"
 
 # Load environment variables securely
 if [ -f "$ENV_FILE" ]; then

--- a/scripts/start_robot.sh
+++ b/scripts/start_robot.sh
@@ -27,19 +27,29 @@ start_jetson_nano_nodes() {
 # Function to start the UI on MacBook
 start_ui() {
     echo "Starting the UI..."
-    cd /Users/abel_elreaper/Desktop/Omega-Code/ui/robot-controller-ui
+    cd "$ROOT_DIR/ui/robot-controller-ui"
     npm start
 }
 
 # Function to start the Go backend server
 start_go_backend() {
     echo "Starting Go backend server..."
-    cd /Users/abel_elreaper/Desktop/Omega-Code/servers/robot-controller-backend
+    cd "$ROOT_DIR/servers/robot-controller-backend"
     go run main_combined.go &
 }
 
 # Load environment variables from .env file
-source /Users/abel_elreaper/Desktop/Omega-Code/servers/robot-controller-backend/.env
+# Determine project root. Allow override via OMEGA_CODE_ROOT
+ROOT_DIR="${OMEGA_CODE_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
+
+# Load environment variables from the backend .env file
+ENV_FILE="${ENV_FILE:-$ROOT_DIR/servers/robot-controller-backend/.env}"
+if [ -f "$ENV_FILE" ]; then
+    source "$ENV_FILE"
+else
+    echo "Environment file not found: $ENV_FILE" >&2
+    exit 1
+fi
 
 # Main script execution
 main() {

--- a/servers/robot-controller-backend/organize_tests.sh
+++ b/servers/robot-controller-backend/organize_tests.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 
-# Define the base directory
-BASE_DIR="/Users/abel_elreaper/Desktop/Omega-Code/servers/robot-controller-backend/tests"
+# Determine project root. Allow override via OMEGA_CODE_ROOT
+ROOT_DIR="${OMEGA_CODE_ROOT:-$(cd "$(dirname "$0")/../.." && pwd)}"
+
+# Define the base directory for tests
+BASE_DIR="$ROOT_DIR/servers/robot-controller-backend/tests"
 
 # Create directories
 mkdir -p $BASE_DIR/unit

--- a/servers/robot-controller-backend/reorganize_files.py
+++ b/servers/robot-controller-backend/reorganize_files.py
@@ -1,9 +1,13 @@
 import os
 import shutil
 import re
+from pathlib import Path
 
 # Define the paths and the new directory structure
-base_path = "/Users/abel_elreaper/Desktop/Omega-Code/servers/robot-controller-backend"
+# Determine project root and backend directory
+PROJECT_ROOT = Path(os.environ.get("OMEGA_CODE_ROOT", Path(__file__).resolve().parents[1]))
+base_path = PROJECT_ROOT / "servers" / "robot-controller-backend"
+base_path = str(base_path)
 new_structure = {
     "commands": ["command_definitions.py", "command_processor.go"],
     "gpio": ["gpio_real.go", "gpio_mock.go", "gpio_simulator.py"],

--- a/servers/robot-controller-backend/update_test_imports.py
+++ b/servers/robot-controller-backend/update_test_imports.py
@@ -1,8 +1,11 @@
 import os
 import re
+from pathlib import Path
 
 # Define the paths and the new directory structure
-base_path = "/Users/abel_elreaper/Desktop/Omega-Code/servers/robot-controller-backend"
+PROJECT_ROOT = Path(os.environ.get("OMEGA_CODE_ROOT", Path(__file__).resolve().parents[1]))
+base_path = PROJECT_ROOT / "servers" / "robot-controller-backend"
+base_path = str(base_path)
 new_structure = {
     "commands": ["command_definitions.py", "command_processor.go"],
     "gpio": ["gpio_real.go", "gpio_mock.go", "gpio_simulator.py"],


### PR DESCRIPTION
## Summary
- make shell scripts load `.env` relative to `OMEGA_CODE_ROOT`
- allow overriding backend `.env` path with `ENV_FILE`
- make organize_tests and helper Python files use configurable project root
- document new environment variables in README

## Testing
- `pytest servers/robot-controller-backend` *(fails: ModuleNotFoundError: No module named 'cv2')*

------
https://chatgpt.com/codex/tasks/task_e_684608fe86f48332b029a4f0e9df127f