### PR TITLE
Handle optional OpenCV dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,8 +248,14 @@ The repository includes a comprehensive set of tests organized into unit tests, 
 2. Start the frontend development server:
    ```bash
    cd ui/robot-controller-ui
-   npm run dev
-   ```
+  npm run dev
+  ```
+
+### Optional Dependencies
+
+- **OpenCV (`cv2` Python package)** – required for video streaming and image processing. If not installed, the
+  application will warn and disable camera features. Tests that rely on OpenCV are skipped automatically when
+  the module is missing.
 
 ### Usage
 

--- a/ros/scripts/autonomous_driving_with_astar.py
+++ b/ros/scripts/autonomous_driving_with_astar.py
@@ -30,7 +30,12 @@ from std_msgs.msg import Int32MultiArray
 from cv_bridge import CvBridge
 import tensorflow as tf
 import numpy as np
-import cv2
+import warnings
+try:
+    import cv2  # type: ignore
+except ImportError:  # pragma: no cover
+    cv2 = None  # type: ignore
+    warnings.warn("OpenCV not installed. Image processing disabled.", ImportWarning)
 import heapq
 
 # Load the pre-trained model
@@ -111,6 +116,9 @@ class AutonomousDriving:
                      [0, 0, 0, 0, 0]]
 
     def image_callback(self, data):
+        if cv2 is None:
+            rospy.logwarn("OpenCV not available, skipping image processing")
+            return
         self.latest_image = bridge.imgmsg_to_cv2(data, "bgr8")
         self.control_robot()
 

--- a/ros/tests/integration/test_ros_integration.py
+++ b/ros/tests/integration/test_ros_integration.py
@@ -2,6 +2,10 @@
 
 import unittest
 from unittest.mock import patch, MagicMock
+try:
+    import cv2  # type: ignore
+except ImportError:  # pragma: no cover
+    cv2 = None  # type: ignore
 import rospy
 from std_msgs.msg import Int32MultiArray, Float32
 from sensor_msgs.msg import Image
@@ -13,6 +17,7 @@ class TestROSIntegration(unittest.TestCase):
         self.line_pub = rospy.Publisher('line_tracking/data', Int32MultiArray, queue_size=10)
         self.ultrasonic_pub = rospy.Publisher('ultrasonic/distance', Float32, queue_size=10)
 
+    @unittest.skipIf(cv2 is None, "OpenCV not installed")
     @patch('scripts.camera_publisher.cv2.VideoCapture')
     @patch('scripts.camera_publisher.CvBridge')
     @patch('scripts.line_tracking_publisher.GPIO.input', side_effect=[1, 0, 1])

--- a/ros/tests/unit/test_camera_publisher.py
+++ b/ros/tests/unit/test_camera_publisher.py
@@ -2,10 +2,15 @@
 
 import unittest
 from unittest.mock import patch, MagicMock
+try:
+    import cv2  # type: ignore
+except ImportError:  # pragma: no cover
+    cv2 = None  # type: ignore
 import rospy
 from scripts.camera_publisher import publish_camera
 
 class TestCameraPublisher(unittest.TestCase):
+    @unittest.skipIf(cv2 is None, "OpenCV not installed")
     @patch('scripts.camera_publisher.cv2.VideoCapture')
     @patch('scripts.camera_publisher.CvBridge')
     @patch('scripts.camera_publisher.rospy.Publisher')

--- a/servers/robot-controller-backend/tests/integration/video/test_video_server_integration.py
+++ b/servers/robot-controller-backend/tests/integration/video/test_video_server_integration.py
@@ -1,7 +1,11 @@
 # File: /Omega-Code/servers/robot-controller-backend/tests/integration/video/test_video_server_integration.py
 
 import unittest
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
+try:
+    import cv2  # type: ignore
+except ImportError:  # pragma: no cover
+    cv2 = None  # type: ignore
 from video_server import app, VideoStreaming
 
 class TestVideoServerIntegration(unittest.TestCase):
@@ -9,6 +13,7 @@ class TestVideoServerIntegration(unittest.TestCase):
         self.app = app.test_client()
         self.app.testing = True
 
+    @unittest.skipIf(cv2 is None, "OpenCV not installed")
     @patch('video_server.cv2.VideoCapture')
     @patch('video_server.cv2.CascadeClassifier')
     def test_video_feed(self, mock_cascade, mock_capture):

--- a/servers/robot-controller-backend/video/motion_detection.py
+++ b/servers/robot-controller-backend/video/motion_detection.py
@@ -11,7 +11,12 @@ It compares consecutive frames to identify motion and highlights areas where mov
 - Adjustable sensitivity for motion detection.
 """
 
-import cv2
+import warnings
+try:
+    import cv2  # type: ignore
+except ImportError:  # pragma: no cover
+    cv2 = None  # type: ignore
+    warnings.warn("OpenCV not installed. Motion detection disabled.", ImportWarning)
 import numpy as np
 
 class MotionDetector:
@@ -21,6 +26,8 @@ class MotionDetector:
 
     def detect_motion(self, frame):
         """ Detect motion by comparing current frame with the previous one. """
+        if cv2 is None:
+            return frame, False
         if frame is None:
             print("❌ No frame captured")
             return frame, False  # Return original frame with no motion detected

--- a/servers/robot-controller-backend/video/object_tracking.py
+++ b/servers/robot-controller-backend/video/object_tracking.py
@@ -6,35 +6,47 @@
 ✅ Allows tracking a manually selected region
 """
 
-import cv2
+import warnings
+try:
+    import cv2  # type: ignore
+except ImportError:  # pragma: no cover
+    cv2 = None  # type: ignore
+    warnings.warn("OpenCV not installed. Object tracking disabled.", ImportWarning)
 
 class ObjectTracker:
     def __init__(self, tracker_type="CSRT"):
         """ Initialize object tracker. Supported types: CSRT, KCF, MIL, MOSSE """
-        OPENCV_OBJECT_TRACKERS = {
-            "CSRT": cv2.TrackerCSRT_create,
-            "KCF": cv2.TrackerKCF_create,
-            "MIL": cv2.TrackerMIL_create,
-            "MOSSE": cv2.legacy.TrackerMOSSE_create,
-        }
-        self.tracker = OPENCV_OBJECT_TRACKERS[tracker_type]()
+        if cv2 is None:
+            warnings.warn("OpenCV not available. ObjectTracker disabled.", RuntimeWarning)
+            self.tracker = None
+        else:
+            OPENCV_OBJECT_TRACKERS = {
+                "CSRT": cv2.TrackerCSRT_create,
+                "KCF": cv2.TrackerKCF_create,
+                "MIL": cv2.TrackerMIL_create,
+                "MOSSE": cv2.legacy.TrackerMOSSE_create,
+            }
+            self.tracker = OPENCV_OBJECT_TRACKERS[tracker_type]()
         self.bounding_box = None  # Bounding box of the object being tracked
         self.tracking = False
 
     def start_tracking(self, frame, bounding_box):
         """ Initialize tracking with a selected bounding box. """
+        if self.tracker is None:
+            return
         self.bounding_box = bounding_box
         self.tracking = self.tracker.init(frame, bounding_box)
 
     def update_tracking(self, frame):
         """ Update object tracking and draw bounding box. """
-        if not self.tracking:
+        if self.tracker is None or not self.tracking:
             return frame, False
 
         success, box = self.tracker.update(frame)
         if success:
             (x, y, w, h) = [int(v) for v in box]
-            cv2.rectangle(frame, (x, y), (x + w, y + h), (255, 0, 0), 2)  # Blue box
+            if cv2 is not None:
+                cv2.rectangle(frame, (x, y), (x + w, y + h), (255, 0, 0), 2)  # Blue box
             return frame, True
         else:
             self.tracking = False

--- a/servers/robot-controller-backend/video/test_camera.py
+++ b/servers/robot-controller-backend/video/test_camera.py
@@ -1,6 +1,14 @@
-import cv2
+import warnings
+try:
+    import cv2  # type: ignore
+except ImportError:  # pragma: no cover
+    cv2 = None  # type: ignore
+    warnings.warn("OpenCV not installed. Camera test disabled.", ImportWarning)
 
 def test_camera():
+    if cv2 is None:
+        print("OpenCV not installed. Skipping camera test.")
+        return
     device = '/dev/video0'  # Correct device based on your previous outputs
     gst_str = f"v4l2src device={device} ! videoconvert ! appsink"
     


### PR DESCRIPTION
## Summary
- guard all `cv2` imports and disable camera logic when OpenCV is missing
- skip integration tests that require OpenCV
- document the optional OpenCV dependency

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rospy')*
- `go test ./...` *(fails: directory prefix . does not contain main module)*

------
https://chatgpt.com/codex/tasks/task_e_68460db12f848332a96505f6b1bb345b