### PR TITLE
Add modular autonomy control backend

### DIFF
--- a/servers/robot-controller-backend/autonomy/__init__.py
+++ b/servers/robot-controller-backend/autonomy/__init__.py
@@ -1,0 +1,30 @@
+"""Autonomy control subsystem."""
+
+from __future__ import annotations
+
+from typing import Mapping
+
+from .base import AutonomyError, AutonomyModeHandler
+from .controller import AutonomyController, ModeRegistry
+from .modes.simple import DEFAULT_MODE_FACTORIES
+
+__all__ = [
+    "AutonomyController",
+    "AutonomyError",
+    "AutonomyModeHandler",
+    "ModeRegistry",
+    "build_default_registry",
+    "build_default_controller",
+]
+
+
+def build_default_registry() -> ModeRegistry:
+    registry = ModeRegistry()
+    for name, factory in DEFAULT_MODE_FACTORIES().items():
+        registry.register(name, factory)
+    return registry
+
+
+def build_default_controller(*, context: Mapping[str, object] | None = None):
+    registry = build_default_registry()
+    return AutonomyController(registry, context=context)

--- a/servers/robot-controller-backend/autonomy/base.py
+++ b/servers/robot-controller-backend/autonomy/base.py
@@ -1,0 +1,80 @@
+"""Core primitives for the autonomy control subsystem.
+
+This module defines the :class:`AutonomyModeHandler` contract used by the
+backend autonomy controller.  Handlers encapsulate the behaviour for a single
+mode ("patrol", "line_follow", etc.) and expose optional hooks that can be
+implemented depending on the capabilities of the mode.
+
+Handlers are intentionally light weight so that they can be composed and
+swapped out easily.  They receive a dedicated logger scoped to their mode name
+so implementations can integrate with whatever telemetry or logging pipeline the
+robot uses without knowing about the server itself.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Mapping, MutableMapping
+
+__all__ = [
+    "AutonomyError",
+    "AutonomyModeHandler",
+]
+
+
+class AutonomyError(RuntimeError):
+    """Raised when an autonomy operation cannot be completed."""
+
+
+class AutonomyModeHandler:
+    """Base class for individual autonomy mode handlers.
+
+    Sub-classes should implement :meth:`start` at minimum.  Optional hooks can
+    be implemented when the mode supports additional operations (e.g.
+    :meth:`set_waypoint`).  By default the optional hooks raise
+    :class:`AutonomyError` so the caller can gracefully propagate a structured
+    error back to the UI.
+    """
+
+    name: str
+
+    def __init__(self, name: str, *, logger: logging.Logger | None = None) -> None:
+        self.name = name
+        self.logger = logger or logging.getLogger(f"autonomy.{name}")
+
+    # ------------------------------------------------------------------
+    # Lifecycle hooks
+    # ------------------------------------------------------------------
+    async def start(self, params: Mapping[str, Any]) -> None:  # pragma: no cover - interface
+        """Begin executing the mode with the supplied parameters."""
+        raise NotImplementedError
+
+    async def stop(self) -> None:  # pragma: no cover - default implementation
+        """Stop the mode.  Sub-classes may override to clean up resources."""
+        self.logger.debug("stop() noop for %s", self.name)
+
+    async def update(self, params: Mapping[str, Any]) -> None:  # pragma: no cover - default implementation
+        """Update the mode with new parameters."""
+        if params:
+            self.logger.debug("update(%s)", dict(params))
+
+    # ------------------------------------------------------------------
+    # Optional hooks
+    # ------------------------------------------------------------------
+    async def dock(self) -> None:  # pragma: no cover - default implementation
+        raise AutonomyError(f"mode '{self.name}' does not implement dock()")
+
+    async def set_waypoint(self, label: str, lat: float, lon: float) -> None:  # pragma: no cover - default implementation
+        raise AutonomyError(f"mode '{self.name}' does not implement set_waypoint()")
+
+    # ------------------------------------------------------------------
+    def snapshot(self) -> MutableMapping[str, Any]:  # pragma: no cover - default implementation
+        """Return a mutable snapshot of the mode state.
+
+        The controller stores the returned mapping to expose richer status data
+        to the UI.  Handlers can override this to surface progress information,
+        diagnostics, etc.  By default we return an empty dict so the caller can
+        mutate it without needing to guard against ``None``.
+        """
+
+        return {}

--- a/servers/robot-controller-backend/autonomy/controller.py
+++ b/servers/robot-controller-backend/autonomy/controller.py
@@ -1,0 +1,229 @@
+"""Autonomy controller orchestrating mode handlers and routing commands.
+
+The controller acts as a tiny runtime responsible for:
+
+* Keeping track of which autonomy mode is currently active.
+* Serialising access across WebSocket commands (``start``/``stop``/``update``).
+* Instantiating handlers from a registry so individual behaviours remain
+  composable and testable in isolation.
+* Normalising all status information into a dictionary that can be surfaced to
+  the UI.
+
+It purposely avoids tying the implementation to a specific web framework so the
+same controller can be reused by the WebSocket server and future HTTP APIs.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import logging
+import time
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, Iterable, Mapping, MutableMapping, Optional
+
+from .base import AutonomyError, AutonomyModeHandler
+
+__all__ = [
+    "ModeRegistry",
+    "AutonomyController",
+]
+
+ModeFactory = Callable[..., AutonomyModeHandler]
+
+
+def _canonical_name(name: str) -> str:
+    cleaned = (name or "").strip().lower().replace("-", "_")
+    if not cleaned:
+        raise AutonomyError("mode name is empty")
+    return cleaned
+
+
+@dataclass(slots=True)
+class _ActiveSession:
+    mode: str
+    handler: AutonomyModeHandler
+    params: MutableMapping[str, Any] = field(default_factory=dict)
+    started_at: float = field(default_factory=lambda: time.time())
+
+    def snapshot(self) -> MutableMapping[str, Any]:
+        snap = self.handler.snapshot()
+        if not isinstance(snap, MutableMapping):
+            snap = dict(snap or {})
+        return snap
+
+
+class ModeRegistry:
+    """Stores factories for autonomy handlers."""
+
+    def __init__(self) -> None:
+        self._factories: Dict[str, ModeFactory] = {}
+
+    def register(self, name: str, factory: ModeFactory) -> None:
+        key = _canonical_name(name)
+        if not callable(factory):
+            raise TypeError("factory must be callable")
+        self._factories[key] = factory
+
+    def get(self, name: str) -> ModeFactory:
+        key = _canonical_name(name)
+        try:
+            return self._factories[key]
+        except KeyError as exc:  # pragma: no cover - exercised via AutonomyController
+            raise AutonomyError(f"unknown autonomy mode '{name}'") from exc
+
+    def has(self, name: str) -> bool:
+        try:
+            self.get(name)
+            return True
+        except AutonomyError:
+            return False
+
+    def create(self, name: str, *, context: Mapping[str, Any], logger: logging.Logger) -> AutonomyModeHandler:
+        factory = self.get(name)
+        # Provide the factory with a mode-specific child logger for consistency.
+        mode_logger = logger.getChild(_canonical_name(name))
+        try:
+            handler = factory(context=context, logger=mode_logger)
+        except TypeError:
+            try:
+                handler = factory(context)
+            except TypeError:
+                handler = factory()
+        if not isinstance(handler, AutonomyModeHandler):
+            raise AutonomyError(f"factory for mode '{name}' did not return an AutonomyModeHandler")
+        return handler
+
+    def available_modes(self) -> Iterable[str]:
+        return sorted(self._factories.keys())
+
+
+class AutonomyController:
+    """Coordinates autonomy commands coming from the transport layer."""
+
+    def __init__(self, registry: ModeRegistry | None = None, *, context: Mapping[str, Any] | None = None,
+                 logger: logging.Logger | None = None) -> None:
+        self.registry = registry or ModeRegistry()
+        self.context: Dict[str, Any] = dict(context or {})
+        self.logger = logger or logging.getLogger("autonomy")
+        self._lock = asyncio.Lock()
+        self._session: Optional[_ActiveSession] = None
+
+    # ------------------------------------------------------------------
+    def status(self) -> Dict[str, Any]:
+        if not self._session:
+            return {
+                "active": False,
+                "mode": "idle",
+                "params": {},
+                "availableModes": list(self.registry.available_modes()),
+            }
+        snap = self._session.params.copy()
+        snap.update(self._session.snapshot())
+        return {
+            "active": True,
+            "mode": self._session.mode,
+            "params": snap,
+            "startedAt": self._session.started_at,
+            "handler": type(self._session.handler).__name__,
+            "availableModes": list(self.registry.available_modes()),
+        }
+
+    # ------------------------------------------------------------------
+    async def start(self, mode: str, params: Mapping[str, Any] | None = None) -> Dict[str, Any]:
+        canonical = _canonical_name(mode)
+        clean_params = self._ensure_mapping(params)
+        async with self._lock:
+            handler = self.registry.create(canonical, context=self.context, logger=self.logger)
+            await self._stop_active_locked()
+            await self._call(handler.start, clean_params)
+            session = _ActiveSession(mode=canonical, handler=handler, params=dict(clean_params))
+            session.params.update(session.snapshot())
+            self._session = session
+            self.logger.info("autonomy mode '%s' started", canonical)
+            return self.status()
+
+    async def stop(self) -> Dict[str, Any]:
+        async with self._lock:
+            await self._stop_active_locked()
+            self.logger.info("autonomy stopped")
+            return self.status()
+
+    async def update(self, params: Mapping[str, Any]) -> Dict[str, Any]:
+        clean_params = self._ensure_mapping(params)
+        async with self._lock:
+            session = self._require_session()
+            await self._call(session.handler.update, clean_params)
+            session.params.update(clean_params)
+            session.params.update(session.snapshot())
+            self.logger.debug("autonomy mode '%s' updated -> %s", session.mode, session.params)
+            return self.status()
+
+    async def dock(self) -> Dict[str, Any]:
+        async with self._lock:
+            if self.registry.has("dock") and (not self._session or self._session.mode != "dock"):
+                handler = self.registry.create("dock", context=self.context, logger=self.logger)
+                await self._stop_active_locked()
+                await self._call(handler.start, {})
+                session = _ActiveSession(mode="dock", handler=handler, params={})
+                session.params.update(session.snapshot())
+                self._session = session
+                self.logger.info("autonomy mode 'dock' started")
+                return self.status()
+            session = self._require_session()
+            await self._call(session.handler.dock)
+            session.params.update(session.snapshot())
+            self.logger.info("autonomy dock command acknowledged")
+            return self.status()
+
+    async def set_waypoint(self, label: str, lat: float, lon: float) -> Dict[str, Any]:
+        if not label:
+            raise AutonomyError("waypoint label is required")
+        try:
+            lat_f = float(lat)
+            lon_f = float(lon)
+        except Exception as exc:  # pragma: no cover - validated in tests
+            raise AutonomyError("latitude/longitude must be numbers") from exc
+
+        async with self._lock:
+            session = self._require_session()
+            await self._call(session.handler.set_waypoint, label, lat_f, lon_f)
+            session.params.setdefault("lastWaypoint", {})
+            session.params["lastWaypoint"].update({"label": label, "lat": lat_f, "lon": lon_f, "ts": time.time()})
+            session.params.update(session.snapshot())
+            self.logger.info("autonomy waypoint set -> %s", session.params["lastWaypoint"])
+            return self.status()
+
+    # ------------------------------------------------------------------
+    async def _stop_active_locked(self) -> None:
+        if not self._session:
+            return
+        session, self._session = self._session, None
+        try:
+            await self._call(session.handler.stop)
+        finally:
+            self.logger.debug("autonomy mode '%s' stopped", session.mode)
+
+    def _require_session(self) -> _ActiveSession:
+        if not self._session:
+            raise AutonomyError("no autonomy mode is active")
+        return self._session
+
+    async def _call(self, fn: Callable[..., Any], *args: Any) -> Any:
+        try:
+            result = fn(*args)
+            if inspect.isawaitable(result):
+                return await result
+            return result
+        except AutonomyError:
+            raise
+        except Exception as exc:  # pragma: no cover - caught via tests
+            raise AutonomyError(str(exc)) from exc
+
+    @staticmethod
+    def _ensure_mapping(value: Mapping[str, Any] | None) -> MutableMapping[str, Any]:
+        if value is None:
+            return {}
+        if not isinstance(value, Mapping):
+            raise AutonomyError("params must be a mapping")
+        return dict(value)

--- a/servers/robot-controller-backend/autonomy/modes/simple.py
+++ b/servers/robot-controller-backend/autonomy/modes/simple.py
@@ -1,0 +1,105 @@
+"""Built-in autonomy mode handlers used by the default registry.
+
+The goal of these handlers is to provide sensible development-time behaviour so
+that the UI can interact with the backend immediately.  They intentionally keep
+side-effects to logging so they are safe to run in environments without real
+hardware attached.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Mapping, MutableMapping
+
+from ..base import AutonomyModeHandler, AutonomyError
+
+__all__ = [
+    "IdleMode",
+    "LoggingMode",
+    "WaypointMode",
+    "DockMode",
+    "DEFAULT_MODE_FACTORIES",
+]
+
+
+class IdleMode(AutonomyModeHandler):
+    async def start(self, params: Mapping[str, Any]) -> None:
+        self.logger.info("Robot is now idle (params=%s)", dict(params))
+
+    async def stop(self) -> None:
+        self.logger.info("Leaving idle mode")
+
+
+class LoggingMode(AutonomyModeHandler):
+    """Generic handler that tracks the last parameters it received."""
+
+    def __init__(self, name: str, *, logger=None) -> None:
+        super().__init__(name, logger=logger)
+        self._state: MutableMapping[str, Any] = {}
+
+    async def start(self, params: Mapping[str, Any]) -> None:
+        self._state = dict(params)
+        self._state.setdefault("startedAt", time.time())
+        self.logger.info("Mode '%s' start → %s", self.name, self._state)
+
+    async def update(self, params: Mapping[str, Any]) -> None:
+        self._state.update(dict(params))
+        self.logger.info("Mode '%s' update → %s", self.name, self._state)
+
+    async def stop(self) -> None:
+        self.logger.info("Mode '%s' stopped", self.name)
+
+    def snapshot(self) -> MutableMapping[str, Any]:
+        return dict(self._state)
+
+
+class WaypointMode(LoggingMode):
+    def __init__(self, *, logger=None) -> None:
+        super().__init__("waypoints", logger=logger)
+        self._last_waypoint: MutableMapping[str, Any] | None = None
+
+    async def set_waypoint(self, label: str, lat: float, lon: float) -> None:
+        self._last_waypoint = {"label": label, "lat": lat, "lon": lon, "ts": time.time()}
+        self.logger.info("New waypoint recorded: %s", self._last_waypoint)
+
+    def snapshot(self) -> MutableMapping[str, Any]:
+        snap = super().snapshot()
+        if self._last_waypoint:
+            snap = dict(snap)
+            snap["lastWaypoint"] = dict(self._last_waypoint)
+        return snap
+
+
+class DockMode(LoggingMode):
+    def __init__(self, *, logger=None) -> None:
+        super().__init__("dock", logger=logger)
+        self._dock_requested = False
+
+    async def start(self, params: Mapping[str, Any]) -> None:
+        await super().start(params)
+        self._dock_requested = True
+        self.logger.info("Docking sequence initiated")
+
+    async def dock(self) -> None:
+        if not self._dock_requested:
+            raise AutonomyError("dock() called before start()")
+        self.logger.info("Dock confirmation acknowledged")
+
+
+def DEFAULT_MODE_FACTORIES() -> Mapping[str, Any]:
+    """Return lazily-built factories used by :func:`build_default_registry`."""
+
+    return {
+        "idle": lambda **kw: IdleMode(logger=kw.get("logger")),
+        "patrol": lambda **kw: LoggingMode("patrol", logger=kw.get("logger")),
+        "follow": lambda **kw: LoggingMode("follow", logger=kw.get("logger")),
+        "line_follow": lambda **kw: LoggingMode("line_follow", logger=kw.get("logger")),
+        "avoid_obstacles": lambda **kw: LoggingMode("avoid_obstacles", logger=kw.get("logger")),
+        "edge_detect": lambda **kw: LoggingMode("edge_detect", logger=kw.get("logger")),
+        "waypoints": lambda **kw: WaypointMode(logger=kw.get("logger")),
+        "color_track": lambda **kw: LoggingMode("color_track", logger=kw.get("logger")),
+        "aruco": lambda **kw: LoggingMode("aruco", logger=kw.get("logger")),
+        "person_follow": lambda **kw: LoggingMode("person_follow", logger=kw.get("logger")),
+        "scan_servo": lambda **kw: LoggingMode("scan_servo", logger=kw.get("logger")),
+        "dock": lambda **kw: DockMode(logger=kw.get("logger")),
+    }

--- a/servers/robot-controller-backend/tests/unit/autonomy/test_controller.py
+++ b/servers/robot-controller-backend/tests/unit/autonomy/test_controller.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import pathlib
+import sys
+
+import asyncio
+import pytest
+
+ROOT = pathlib.Path(__file__).resolve().parents[3]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from autonomy import AutonomyController, AutonomyError, ModeRegistry, build_default_controller
+from autonomy.base import AutonomyModeHandler
+
+
+class DummyMode(AutonomyModeHandler):
+    def __init__(self) -> None:
+        super().__init__("dummy")
+        self.started_with = {}
+        self.updated_with = {}
+        self.stopped = False
+
+    async def start(self, params):
+        self.started_with = dict(params)
+
+    async def update(self, params):
+        self.updated_with.update(dict(params))
+
+    async def stop(self):
+        self.stopped = True
+
+
+def test_start_and_stop_cycle():
+    registry = ModeRegistry()
+    registry.register("dummy", lambda **_: DummyMode())
+    controller = AutonomyController(registry)
+
+    async def scenario():
+        status = await controller.start("dummy", {"speed": 42})
+        assert status["active"] is True
+        assert status["mode"] == "dummy"
+        assert status["params"]["speed"] == 42
+
+        status = await controller.update({"speed": 55})
+        assert status["params"]["speed"] == 55
+
+        status = await controller.stop()
+        assert status["active"] is False
+
+        with pytest.raises(AutonomyError):
+            await controller.update({"speed": 99})
+
+    asyncio.run(scenario())
+
+
+def test_dock_falls_back_to_dock_mode():
+    controller = build_default_controller()
+
+    async def scenario():
+        # Start patrol first to exercise stop/start sequencing
+        await controller.start("patrol", {"loops": 2})
+        status = await controller.dock()
+        assert status["mode"] == "dock"
+        assert status["active"] is True
+
+    asyncio.run(scenario())
+
+
+def test_waypoint_updates_tracked():
+    controller = build_default_controller()
+
+    async def scenario():
+        await controller.start("waypoints", {"existing": 1})
+        status = await controller.set_waypoint("Home", 12.34, -45.6)
+        waypoint = status["params"]["lastWaypoint"]
+        assert waypoint["label"] == "Home"
+        assert waypoint["lat"] == pytest.approx(12.34)
+        assert waypoint["lon"] == pytest.approx(-45.6)
+
+    asyncio.run(scenario())
+
+
+def test_invalid_mode_raises():
+    controller = build_default_controller()
+
+    async def scenario():
+        with pytest.raises(AutonomyError):
+            await controller.start("", {})
+
+    asyncio.run(scenario())


### PR DESCRIPTION
## Summary
- add a dedicated autonomy package with base handler abstractions, registry utilities, and simple default mode implementations
- integrate the movement WebSocket server with the autonomy controller so UI commands map to modular handlers and status responses
- cover the new controller behaviour with unit tests for start/stop, docking, waypoints, and validation cases

## Testing
- pytest servers/robot-controller-backend/tests/unit/autonomy/test_controller.py

------
https://chatgpt.com/codex/tasks/task_e_68cb7f6cdadc8332ad4afcb42b53c2fc