### PR TITLE
feat(ui): add macro automation workspace

### DIFF
--- a/ui/robot-controller-ui/src/components/macros/MacroEditor.tsx
+++ b/ui/robot-controller-ui/src/components/macros/MacroEditor.tsx
@@ -1,0 +1,366 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { v4 as uuidv4 } from 'uuid';
+import {
+  DEFAULT_MACRO_COMMAND,
+  MACRO_COMMAND_GROUPS,
+  getMacroCommandLabel,
+} from '@/constants/macroCommands';
+import { Macro, MacroStep, useMacro } from '@/context/MacroContext';
+
+interface MacroEditorProps {
+  macro: Macro;
+}
+
+type DraftState = {
+  text: string;
+  error?: string;
+};
+
+const fieldLabel = 'block text-sm font-medium text-gray-700 mb-1';
+const inputBase =
+  'w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200';
+
+const iconButtonClasses =
+  'inline-flex items-center justify-center rounded-md border border-gray-300 bg-white px-2 py-1 text-xs font-medium text-gray-700 shadow-sm hover:bg-gray-50 disabled:opacity-40 disabled:cursor-not-allowed';
+
+const dangerButtonClasses =
+  'inline-flex items-center justify-center rounded-md border border-red-200 bg-red-50 px-2 py-1 text-xs font-medium text-red-600 shadow-sm hover:bg-red-100 disabled:opacity-40 disabled:cursor-not-allowed';
+
+const addButtonClasses =
+  'inline-flex items-center justify-center rounded-md border border-indigo-200 bg-indigo-50 px-3 py-2 text-sm font-medium text-indigo-700 shadow-sm hover:bg-indigo-100';
+
+const MacroEditor: React.FC<MacroEditorProps> = ({ macro }) => {
+  const { updateMacro, addStep, updateStep, removeStep, moveStep, runtime, isRunning } = useMacro();
+
+  const [payloadDrafts, setPayloadDrafts] = useState<Record<string, DraftState>>({});
+  const lastMacroIdRef = useRef<string | null>(null);
+
+  const descriptionLookup = useMemo(() => {
+    const map = new Map<string, string | undefined>();
+    for (const group of MACRO_COMMAND_GROUPS) {
+      for (const option of group.options) {
+        map.set(option.value, option.description);
+      }
+    }
+    return map;
+  }, []);
+
+  useEffect(() => {
+    if (lastMacroIdRef.current === macro.id) {
+      return;
+    }
+    lastMacroIdRef.current = macro.id;
+    const initial: Record<string, DraftState> = {};
+    macro.steps.forEach((step) => {
+      initial[step.id] = {
+        text: step.payload ? JSON.stringify(step.payload, null, 2) : '',
+        error: undefined,
+      };
+    });
+    setPayloadDrafts(initial);
+  }, [macro.id, macro.steps]);
+
+  useEffect(() => {
+    setPayloadDrafts((prev) => {
+      const next: Record<string, DraftState> = {};
+      macro.steps.forEach((step) => {
+        next[step.id] = prev[step.id] ?? {
+          text: step.payload ? JSON.stringify(step.payload, null, 2) : '',
+          error: undefined,
+        };
+      });
+      return next;
+    });
+  }, [macro.steps]);
+
+  const handleNameChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      updateMacro(macro.id, { name: event.target.value });
+    },
+    [macro.id, updateMacro],
+  );
+
+  const handleDescriptionChange = useCallback(
+    (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+      updateMacro(macro.id, { description: event.target.value });
+    },
+    [macro.id, updateMacro],
+  );
+
+  const handleAddStep = useCallback(() => {
+    const newStep: MacroStep = {
+      id: uuidv4(),
+      command: DEFAULT_MACRO_COMMAND,
+      delayMs: 0,
+    };
+    addStep(macro.id, newStep);
+  }, [addStep, macro.id]);
+
+  const handleLabelChange = useCallback(
+    (stepId: string, value: string) => {
+      updateStep(macro.id, stepId, { label: value || undefined });
+    },
+    [macro.id, updateStep],
+  );
+
+  const handleCommandChange = useCallback(
+    (stepId: string, value: string) => {
+      updateStep(macro.id, stepId, { command: value });
+    },
+    [macro.id, updateStep],
+  );
+
+  const handleDelayChange = useCallback(
+    (stepId: string, value: string) => {
+      const parsed = Number(value);
+      const sanitized = Number.isFinite(parsed) ? Math.max(0, Math.round(parsed)) : 0;
+      updateStep(macro.id, stepId, { delayMs: sanitized });
+    },
+    [macro.id, updateStep],
+  );
+
+  const handlePayloadChange = useCallback(
+    (stepId: string, text: string) => {
+      setPayloadDrafts((prev) => ({
+        ...prev,
+        [stepId]: {
+          text,
+          error: prev[stepId]?.error,
+        },
+      }));
+
+      if (text.trim() === '') {
+        updateStep(macro.id, stepId, { payload: undefined });
+        setPayloadDrafts((prev) => ({
+          ...prev,
+          [stepId]: { text: '', error: undefined },
+        }));
+        return;
+      }
+
+      try {
+        const parsed = JSON.parse(text);
+        updateStep(macro.id, stepId, { payload: parsed });
+        setPayloadDrafts((prev) => ({
+          ...prev,
+          [stepId]: { text, error: undefined },
+        }));
+      } catch {
+        setPayloadDrafts((prev) => ({
+          ...prev,
+          [stepId]: { text, error: 'Invalid JSON payload' },
+        }));
+      }
+    },
+    [macro.id, updateStep],
+  );
+
+  const handleRemoveStep = useCallback(
+    (stepId: string) => {
+      const step = macro.steps.find((s) => s.id === stepId);
+      const label = step?.label || getMacroCommandLabel(step?.command || '');
+      const shouldDelete =
+        typeof window === 'undefined'
+          ? true
+          : window.confirm(`Remove step "${label}"?`);
+      if (!shouldDelete) return;
+      removeStep(macro.id, stepId);
+      setPayloadDrafts((prev) => {
+        const { [stepId]: _removed, ...rest } = prev;
+        return rest;
+      });
+    },
+    [macro.id, macro.steps, removeStep],
+  );
+
+  const handleMoveStep = useCallback(
+    (currentIndex: number, direction: -1 | 1) => {
+      const nextIndex = currentIndex + direction;
+      moveStep(macro.id, currentIndex, nextIndex);
+    },
+    [macro.id, moveStep],
+  );
+
+  const activeStepIndex = useMemo(() => {
+    if (runtime.runningId !== macro.id) return -1;
+    return runtime.stepIndex;
+  }, [macro.id, runtime]);
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <label className={fieldLabel} htmlFor={`macro-name-${macro.id}`}>
+          Macro Name
+        </label>
+        <input
+          id={`macro-name-${macro.id}`}
+          className={inputBase}
+          value={macro.name}
+          placeholder="Untitled macro"
+          onChange={handleNameChange}
+        />
+      </div>
+
+      <div>
+        <label className={fieldLabel} htmlFor={`macro-description-${macro.id}`}>
+          Notes (optional)
+        </label>
+        <textarea
+          id={`macro-description-${macro.id}`}
+          className={`${inputBase} min-h-[72px]`}
+          value={macro.description ?? ''}
+          placeholder="Describe what this macro does for future you…"
+          onChange={handleDescriptionChange}
+        />
+      </div>
+
+      <div className="flex items-center justify-between">
+        <h3 className="text-base font-semibold text-gray-900">Steps</h3>
+        <button type="button" className={addButtonClasses} onClick={handleAddStep}>
+          + Add Step
+        </button>
+      </div>
+
+      {macro.steps.length === 0 ? (
+        <p className="text-sm text-gray-500">
+          No steps yet. Add steps to orchestrate a sequence of commands.
+        </p>
+      ) : (
+        <div className="space-y-4">
+          {macro.steps.map((step, index) => {
+            const draft = payloadDrafts[step.id] ?? { text: '' };
+            const isActive = activeStepIndex === index && isRunning;
+            const isDone = isRunning && runtime.runningId === macro.id && runtime.stepIndex > index;
+            return (
+              <div
+                key={step.id}
+                className={`rounded-xl border bg-white p-4 shadow-sm transition ${
+                  isActive
+                    ? 'border-indigo-400 ring-2 ring-indigo-200'
+                    : isDone
+                    ? 'border-emerald-200'
+                    : 'border-gray-200'
+                }`}
+              >
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <div className="text-sm font-semibold text-gray-800">
+                    Step {index + 1}
+                    {step.label ? ` · ${step.label}` : ''}
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <button
+                      type="button"
+                      className={iconButtonClasses}
+                      onClick={() => handleMoveStep(index, -1)}
+                      disabled={index === 0}
+                    >
+                      ↑
+                    </button>
+                    <button
+                      type="button"
+                      className={iconButtonClasses}
+                      onClick={() => handleMoveStep(index, 1)}
+                      disabled={index === macro.steps.length - 1}
+                    >
+                      ↓
+                    </button>
+                    <button
+                      type="button"
+                      className={dangerButtonClasses}
+                      onClick={() => handleRemoveStep(step.id)}
+                    >
+                      Remove
+                    </button>
+                  </div>
+                </div>
+
+                <div className="mt-3 grid gap-4 md:grid-cols-2">
+                  <div>
+                    <label className={fieldLabel} htmlFor={`macro-${macro.id}-step-${step.id}-label`}>
+                      Friendly label (optional)
+                    </label>
+                    <input
+                      id={`macro-${macro.id}-step-${step.id}-label`}
+                      className={inputBase}
+                      value={step.label ?? ''}
+                      placeholder="e.g. Move off the line"
+                      onChange={(event) => handleLabelChange(step.id, event.target.value)}
+                    />
+                  </div>
+                  <div>
+                    <label className={fieldLabel} htmlFor={`macro-${macro.id}-step-${step.id}-command`}>
+                      Command
+                    </label>
+                    <select
+                      id={`macro-${macro.id}-step-${step.id}-command`}
+                      className={inputBase}
+                      value={step.command}
+                      onChange={(event) => handleCommandChange(step.id, event.target.value)}
+                    >
+                      {MACRO_COMMAND_GROUPS.map((group) => (
+                        <optgroup key={group.group} label={group.group}>
+                          {group.options.map((option) => (
+                            <option key={option.value} value={option.value}>
+                              {option.label}
+                            </option>
+                          ))}
+                        </optgroup>
+                      ))}
+                    </select>
+                  </div>
+                </div>
+
+                <div className="mt-4 grid gap-4 md:grid-cols-2">
+                  <div>
+                    <label className={fieldLabel} htmlFor={`macro-${macro.id}-step-${step.id}-delay`}>
+                      Delay after command (ms)
+                    </label>
+                    <input
+                      id={`macro-${macro.id}-step-${step.id}-delay`}
+                      className={inputBase}
+                      type="number"
+                      min={0}
+                      step={50}
+                      value={step.delayMs ?? 0}
+                      onChange={(event) => handleDelayChange(step.id, event.target.value)}
+                    />
+                    <p className="mt-1 text-xs text-gray-500">
+                      Wait before the next step. Use 0 for immediate execution.
+                    </p>
+                  </div>
+                  <div>
+                    <label className={fieldLabel} htmlFor={`macro-${macro.id}-step-${step.id}-payload`}>
+                      Payload (JSON)
+                    </label>
+                    <textarea
+                      id={`macro-${macro.id}-step-${step.id}-payload`}
+                      className={`${inputBase} min-h-[96px] font-mono text-xs`}
+                      value={draft.text}
+                      onChange={(event) => handlePayloadChange(step.id, event.target.value)}
+                      placeholder="{ &quot;value&quot;: 2048 }"
+                    />
+                    {draft.error ? (
+                      <p className="mt-1 text-xs text-red-600">{draft.error}</p>
+                    ) : (
+                      <p className="mt-1 text-xs text-gray-500">
+                        Leave blank for commands without parameters.
+                      </p>
+                    )}
+                    {descriptionLookup.get(step.command) ? (
+                      <p className="mt-1 text-xs text-gray-400">
+                        {descriptionLookup.get(step.command)}
+                      </p>
+                    ) : null}
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default MacroEditor;
+

--- a/ui/robot-controller-ui/src/components/macros/MacroManager.tsx
+++ b/ui/robot-controller-ui/src/components/macros/MacroManager.tsx
@@ -1,0 +1,260 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import MacroEditor from './MacroEditor';
+import { useMacro } from '@/context/MacroContext';
+import { getMacroCommandLabel } from '@/constants/macroCommands';
+import { useCommand } from '@/context/CommandContext';
+
+const listButtonBase =
+  'w-full rounded-xl border px-4 py-3 text-left shadow-sm transition focus:outline-none focus:ring-2 focus:ring-indigo-300';
+
+const actionButton =
+  'inline-flex items-center justify-center rounded-md border border-gray-300 bg-white px-3 py-1 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 disabled:opacity-40 disabled:cursor-not-allowed';
+
+const primaryButton =
+  'inline-flex items-center justify-center rounded-md border border-indigo-600 bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 disabled:opacity-50';
+
+const secondaryButton =
+  'inline-flex items-center justify-center rounded-md border border-gray-200 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-100 disabled:opacity-40';
+
+const dangerButton =
+  'inline-flex items-center justify-center rounded-md border border-red-200 bg-red-50 px-3 py-1 text-sm font-medium text-red-600 shadow-sm hover:bg-red-100';
+
+const MacroManager: React.FC = () => {
+  const {
+    macros,
+    isLoaded,
+    createMacro,
+    deleteMacro,
+    duplicateMacro,
+    runMacro,
+    stopMacro,
+    runtime,
+    isRunning,
+    stopRequested,
+  } = useMacro();
+  const { addCommand } = useCommand();
+
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (macros.length === 0) {
+      setSelectedId(null);
+      return;
+    }
+    if (!selectedId || !macros.some((macro) => macro.id === selectedId)) {
+      setSelectedId(macros[0].id);
+    }
+  }, [macros, selectedId]);
+
+  const selectedMacro = useMemo(
+    () => macros.find((macro) => macro.id === selectedId) ?? null,
+    [macros, selectedId],
+  );
+
+  const runningMacro = useMemo(
+    () => (runtime.runningId ? macros.find((macro) => macro.id === runtime.runningId) : undefined),
+    [macros, runtime.runningId],
+  );
+
+  const formatTimestamp = useCallback((timestamp: number) => {
+    try {
+      return new Intl.DateTimeFormat(undefined, {
+        hour: '2-digit',
+        minute: '2-digit',
+        month: 'short',
+        day: 'numeric',
+      }).format(new Date(timestamp));
+    } catch {
+      return new Date(timestamp).toLocaleString();
+    }
+  }, []);
+
+  const handleCreate = useCallback(() => {
+    const macro = createMacro(`Macro ${macros.length + 1}`);
+    addCommand(`Macro created: ${macro.name}`);
+    setSelectedId(macro.id);
+  }, [addCommand, createMacro, macros.length]);
+
+  const handleRun = useCallback(
+    (macroId: string) => {
+      runMacro(macroId).catch((error) => {
+        const message = error instanceof Error ? error.message : String(error);
+        addCommand(`Macro failed to start: ${message}`);
+      });
+    },
+    [addCommand, runMacro],
+  );
+
+  const handleDuplicate = useCallback(
+    (macroId: string) => {
+      const copy = duplicateMacro(macroId);
+      if (copy) {
+        addCommand(`Macro duplicated: ${copy.name}`);
+        setSelectedId(copy.id);
+      }
+    },
+    [addCommand, duplicateMacro],
+  );
+
+  const handleDelete = useCallback(
+    (macroId: string) => {
+      const macro = macros.find((m) => m.id === macroId);
+      const name = macro?.name || 'Macro';
+      const shouldDelete =
+        typeof window === 'undefined' ? true : window.confirm(`Delete "${name}"? This cannot be undone.`);
+      if (!shouldDelete) return;
+      deleteMacro(macroId);
+      addCommand(`Macro deleted: ${name}`);
+      if (selectedId === macroId) {
+        setSelectedId(null);
+      }
+    },
+    [addCommand, deleteMacro, macros, selectedId],
+  );
+
+  const recentCommand = useMemo(() => {
+    if (!runningMacro || runtime.stepIndex < 0) return null;
+    const step = runningMacro.steps[runtime.stepIndex];
+    if (!step) return null;
+    return step.label || getMacroCommandLabel(step.command);
+  }, [runningMacro, runtime.stepIndex]);
+
+  if (!isLoaded) {
+    return (
+      <section className="mx-auto w-full max-w-6xl rounded-2xl border border-gray-200 bg-white/80 p-6 shadow-sm">
+        <h2 className="text-lg font-semibold text-gray-800">Macro Automation</h2>
+        <p className="mt-2 text-sm text-gray-500">Loading saved macros…</p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="mx-auto w-full max-w-6xl rounded-2xl border border-gray-200 bg-white/90 p-6 shadow-lg backdrop-blur-sm">
+      <div className="flex flex-col gap-4">
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+          <div>
+            <h2 className="text-xl font-bold text-gray-900">Macro Automation (Beta)</h2>
+            <p className="text-sm text-gray-600">
+              Orchestrate repeatable command sequences without writing ROS nodes. Macros run through the
+              standard WebSocket interface, so they work anywhere the UI does.
+            </p>
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            {isRunning ? (
+              <button type="button" className={secondaryButton} onClick={stopMacro}>
+                Stop macro
+              </button>
+            ) : null}
+            <button type="button" className={primaryButton} onClick={handleCreate}>
+              New macro
+            </button>
+          </div>
+        </div>
+
+        {isRunning && runningMacro ? (
+          <div className="rounded-xl border border-indigo-200 bg-indigo-50 p-4 text-sm text-indigo-900 shadow-inner">
+            <div className="font-semibold">
+              Running “{runningMacro.name}” — step {runtime.stepIndex + 1} of {runningMacro.steps.length}
+            </div>
+            {recentCommand ? <div className="mt-1">Current command: {recentCommand}</div> : null}
+            {stopRequested ? (
+              <div className="mt-1 text-xs text-indigo-700">Stop requested — finishing current step…</div>
+            ) : null}
+          </div>
+        ) : null}
+
+        <div className="grid gap-6 lg:grid-cols-[minmax(240px,280px)_1fr]">
+          <div className="space-y-3">
+            {macros.length === 0 ? (
+              <div className="rounded-xl border border-dashed border-gray-300 bg-gray-50 p-4 text-sm text-gray-500">
+                No macros yet. Create one to start chaining commands.
+              </div>
+            ) : (
+              macros.map((macro) => {
+                const isSelected = macro.id === selectedId;
+                return (
+                  <div
+                    key={macro.id}
+                    className={`${
+                      isSelected
+                        ? 'border-indigo-300 bg-indigo-50/80'
+                        : 'border-gray-200 bg-white'
+                    } ${listButtonBase}`}
+                    onClick={() => setSelectedId(macro.id)}
+                    role="button"
+                    tabIndex={0}
+                    onKeyDown={(event) => {
+                      if (event.key === 'Enter' || event.key === ' ') {
+                        event.preventDefault();
+                        setSelectedId(macro.id);
+                      }
+                    }}
+                  >
+                    <div className="flex items-start justify-between gap-2">
+                      <div>
+                        <div className="text-base font-semibold text-gray-900">{macro.name || 'Untitled macro'}</div>
+                        <div className="mt-1 text-xs text-gray-500">
+                          {macro.steps.length} step{macro.steps.length === 1 ? '' : 's'} · Updated {formatTimestamp(macro.updatedAt)}
+                        </div>
+                      </div>
+                      <div className="flex flex-col gap-1 text-xs text-gray-400">
+                        <button
+                          type="button"
+                          className={`${actionButton} px-2 py-1`}
+                          onClick={(event) => {
+                            event.stopPropagation();
+                            handleRun(macro.id);
+                          }}
+                          disabled={isRunning && runtime.runningId !== macro.id}
+                        >
+                          Run
+                        </button>
+                        <button
+                          type="button"
+                          className={`${actionButton} px-2 py-1`}
+                          onClick={(event) => {
+                            event.stopPropagation();
+                            handleDuplicate(macro.id);
+                          }}
+                        >
+                          Duplicate
+                        </button>
+                        <button
+                          type="button"
+                          className={`${dangerButton} px-2 py-1`}
+                          onClick={(event) => {
+                            event.stopPropagation();
+                            handleDelete(macro.id);
+                          }}
+                        >
+                          Delete
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                );
+              })
+            )}
+          </div>
+
+          <div className="min-h-[320px] rounded-2xl border border-gray-200 bg-white p-5 shadow-inner">
+            {selectedMacro ? (
+              <MacroEditor macro={selectedMacro} />
+            ) : macros.length === 0 ? (
+              <div className="flex h-full flex-col items-center justify-center text-center text-sm text-gray-500">
+                Create a macro on the left to start building automation sequences.
+              </div>
+            ) : (
+              <div className="flex h-full flex-col items-center justify-center text-center text-sm text-gray-500">
+                Select a macro to edit its steps.
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default MacroManager;
+

--- a/ui/robot-controller-ui/src/constants/macroCommands.ts
+++ b/ui/robot-controller-ui/src/constants/macroCommands.ts
@@ -1,0 +1,130 @@
+import { COMMAND } from '@/control_definitions';
+
+export interface MacroCommandOption {
+  value: string;
+  label: string;
+  description?: string;
+}
+
+export interface MacroCommandGroup {
+  group: string;
+  options: MacroCommandOption[];
+}
+
+export const MACRO_COMMAND_GROUPS: MacroCommandGroup[] = [
+  {
+    group: 'Movement',
+    options: [
+      { value: COMMAND.MOVE_UP, label: 'Move Forward (up)' },
+      { value: COMMAND.MOVE_DOWN, label: 'Move Backward (down)' },
+      { value: COMMAND.MOVE_LEFT, label: 'Strafe Left' },
+      { value: COMMAND.MOVE_RIGHT, label: 'Strafe Right' },
+      { value: COMMAND.MOVE_STOP, label: 'Stop (alias)' },
+      { value: COMMAND.STOP, label: 'Emergency Stop' },
+    ],
+  },
+  {
+    group: 'Speed',
+    options: [
+      {
+        value: COMMAND.SET_SPEED,
+        label: 'Set Speed (absolute)',
+        description: 'Payload: { "value": 0-4095 }',
+      },
+      {
+        value: COMMAND.INCREASE_SPEED,
+        label: 'Increase Speed',
+        description: 'Optional payload: { "step": number }',
+      },
+      {
+        value: COMMAND.DECREASE_SPEED,
+        label: 'Decrease Speed',
+        description: 'Optional payload: { "step": number }',
+      },
+    ],
+  },
+  {
+    group: 'Camera & Servo',
+    options: [
+      {
+        value: COMMAND.SERVO_HORIZONTAL,
+        label: 'Servo Horizontal (relative)',
+        description: 'Payload: { "angle": +/- number }',
+      },
+      {
+        value: COMMAND.SERVO_VERTICAL,
+        label: 'Servo Vertical (relative)',
+        description: 'Payload: { "angle": +/- number }',
+      },
+      {
+        value: COMMAND.SET_SERVO_POSITION,
+        label: 'Set Servo Position',
+        description: 'Payload: { "horizontal"?: 0-180, "vertical"?: 0-180 }',
+      },
+      { value: COMMAND.RESET_SERVO, label: 'Reset Camera Servo' },
+      { value: COMMAND.CAMERA_SERVO_LEFT, label: 'Camera Nudge Left' },
+      { value: COMMAND.CAMERA_SERVO_RIGHT, label: 'Camera Nudge Right' },
+      { value: COMMAND.CAMERA_SERVO_UP, label: 'Camera Nudge Up' },
+      { value: COMMAND.CAMERA_SERVO_DOWN, label: 'Camera Nudge Down' },
+    ],
+  },
+  {
+    group: 'Lighting',
+    options: [
+      {
+        value: COMMAND.SET_LED,
+        label: 'Set LED (legacy)',
+        description: 'Payload: { "color": "#RRGGBB" }',
+      },
+      {
+        value: COMMAND.LIGHTING_SET_COLOR,
+        label: 'Lighting: Set Color',
+        description: 'Payload: { "hex": "#RRGGBB" }',
+      },
+      {
+        value: COMMAND.LIGHTING_SET_MODE,
+        label: 'Lighting: Set Mode',
+        description: 'Payload: { "mode": "single" | "multi" | "two" }',
+      },
+      {
+        value: COMMAND.LIGHTING_SET_PATTERN,
+        label: 'Lighting: Set Pattern',
+        description: 'Payload: { "pattern": string }',
+      },
+      {
+        value: COMMAND.LIGHTING_SET_INTERVAL,
+        label: 'Lighting: Set Interval',
+        description: 'Payload: { "ms": number }',
+      },
+      { value: COMMAND.LIGHTING_TOGGLE, label: 'Lighting: Toggle On/Off' },
+    ],
+  },
+  {
+    group: 'Buzzer',
+    options: [
+      { value: COMMAND.CMD_BUZZER, label: 'Buzzer On' },
+      { value: COMMAND.CMD_BUZZER_STOP, label: 'Buzzer Off' },
+    ],
+  },
+  {
+    group: 'Status / Misc',
+    options: [
+      { value: COMMAND.STATUS, label: 'Request Status Snapshot' },
+    ],
+  },
+];
+
+const labelLookup = new Map<string, string>();
+for (const group of MACRO_COMMAND_GROUPS) {
+  for (const option of group.options) {
+    if (!labelLookup.has(option.value)) {
+      labelLookup.set(option.value, option.label);
+    }
+  }
+}
+
+export const DEFAULT_MACRO_COMMAND = COMMAND.MOVE_UP;
+
+export const getMacroCommandLabel = (command: string): string =>
+  labelLookup.get(command) ?? command;
+

--- a/ui/robot-controller-ui/src/context/MacroContext.tsx
+++ b/ui/robot-controller-ui/src/context/MacroContext.tsx
@@ -1,0 +1,386 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
+import { v4 as uuidv4 } from 'uuid';
+import { useCommand } from './CommandContext';
+
+const STORAGE_KEY = 'omega.macros.v1';
+
+export interface MacroStep {
+  id: string;
+  command: string;
+  label?: string;
+  payload?: Record<string, any>;
+  delayMs?: number;
+}
+
+export interface Macro {
+  id: string;
+  name: string;
+  description?: string;
+  steps: MacroStep[];
+  createdAt: number;
+  updatedAt: number;
+}
+
+type RuntimeState = {
+  runningId: string | null;
+  stepIndex: number;
+  startedAt: number | null;
+};
+
+type MacroContextType = {
+  macros: Macro[];
+  isLoaded: boolean;
+  createMacro: (name?: string, description?: string) => Macro;
+  updateMacro: (
+    id: string,
+    updates: Partial<Omit<Macro, 'id' | 'createdAt' | 'updatedAt' | 'steps'>> & {
+      steps?: MacroStep[];
+    },
+  ) => void;
+  deleteMacro: (id: string) => void;
+  duplicateMacro: (id: string) => Macro | undefined;
+  addStep: (macroId: string, step: MacroStep) => void;
+  updateStep: (macroId: string, stepId: string, updates: Partial<MacroStep>) => void;
+  removeStep: (macroId: string, stepId: string) => void;
+  moveStep: (macroId: string, fromIndex: number, toIndex: number) => void;
+  runMacro: (id: string) => Promise<void>;
+  stopMacro: () => void;
+  runtime: RuntimeState;
+  isRunning: boolean;
+  stopRequested: boolean;
+};
+
+const MacroContext = createContext<MacroContextType | undefined>(undefined);
+
+export const useMacro = (): MacroContextType => {
+  const ctx = useContext(MacroContext);
+  if (!ctx) {
+    throw new Error('useMacro must be used within a MacroProvider');
+  }
+  return ctx;
+};
+
+const cloneSteps = (steps: MacroStep[]): MacroStep[] =>
+  steps.map((step) => ({ ...step, id: uuidv4() }));
+
+export const MacroProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
+  const { sendCommand, addCommand } = useCommand();
+
+  const [macros, setMacros] = useState<Macro[]>([]);
+  const [isLoaded, setIsLoaded] = useState(false);
+  const [runtime, setRuntime] = useState<RuntimeState>({ runningId: null, stepIndex: -1, startedAt: null });
+  const [stopRequested, setStopRequested] = useState(false);
+
+  const runtimeRef = useRef(runtime);
+  const stopSignalRef = useRef<{
+    shouldStop: boolean;
+    timer: ReturnType<typeof setTimeout> | null;
+    wake: (() => void) | null;
+  }>({ shouldStop: false, timer: null, wake: null });
+
+  runtimeRef.current = runtime;
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    try {
+      const stored = window.localStorage.getItem(STORAGE_KEY);
+      if (stored) {
+        const parsed: Macro[] = JSON.parse(stored);
+        if (Array.isArray(parsed)) {
+          setMacros(parsed);
+        }
+      }
+    } catch (error) {
+      console.warn('[MacroProvider] Failed to load macros from storage', error);
+    } finally {
+      setIsLoaded(true);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!isLoaded || typeof window === 'undefined') return;
+    try {
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(macros));
+    } catch (error) {
+      console.warn('[MacroProvider] Failed to persist macros', error);
+    }
+  }, [macros, isLoaded]);
+
+  useEffect(
+    () => () => {
+      // Cleanup on unmount
+      const signal = stopSignalRef.current;
+      signal.shouldStop = true;
+      if (signal.timer) clearTimeout(signal.timer);
+      signal.timer = null;
+      if (signal.wake) signal.wake();
+      signal.wake = null;
+    },
+    [],
+  );
+
+  const createMacro = useCallback(
+    (name = 'New Macro', description?: string) => {
+      const now = Date.now();
+      const macro: Macro = {
+        id: uuidv4(),
+        name,
+        description,
+        steps: [],
+        createdAt: now,
+        updatedAt: now,
+      };
+      setMacros((prev) => [...prev, macro]);
+      return macro;
+    },
+    [],
+  );
+
+  const updateMacro = useCallback<MacroContextType['updateMacro']>((id, updates) => {
+    setMacros((prev) =>
+      prev.map((macro) => {
+        if (macro.id !== id) return macro;
+        return {
+          ...macro,
+          ...updates,
+          steps: updates.steps ?? macro.steps,
+          updatedAt: Date.now(),
+        };
+      }),
+    );
+  }, []);
+
+  const deleteMacro = useCallback((id: string) => {
+    setMacros((prev) => prev.filter((macro) => macro.id !== id));
+  }, []);
+
+  const duplicateMacro = useCallback(
+    (id: string) => {
+      const macro = macros.find((m) => m.id === id);
+      if (!macro) return undefined;
+      const now = Date.now();
+      const clone: Macro = {
+        ...macro,
+        id: uuidv4(),
+        name: `${macro.name || 'Macro'} Copy`,
+        steps: cloneSteps(macro.steps),
+        createdAt: now,
+        updatedAt: now,
+      };
+      setMacros((prev) => [...prev, clone]);
+      return clone;
+    },
+    [macros],
+  );
+
+  const addStep = useCallback<MacroContextType['addStep']>((macroId, step) => {
+    setMacros((prev) =>
+      prev.map((macro) => {
+        if (macro.id !== macroId) return macro;
+        return {
+          ...macro,
+          steps: [...macro.steps, step],
+          updatedAt: Date.now(),
+        };
+      }),
+    );
+  }, []);
+
+  const updateStep = useCallback<MacroContextType['updateStep']>((macroId, stepId, updates) => {
+    setMacros((prev) =>
+      prev.map((macro) => {
+        if (macro.id !== macroId) return macro;
+        const steps = macro.steps.map((step) =>
+          step.id === stepId
+            ? {
+                ...step,
+                ...updates,
+              }
+            : step,
+        );
+        return {
+          ...macro,
+          steps,
+          updatedAt: Date.now(),
+        };
+      }),
+    );
+  }, []);
+
+  const removeStep = useCallback<MacroContextType['removeStep']>((macroId, stepId) => {
+    setMacros((prev) =>
+      prev.map((macro) => {
+        if (macro.id !== macroId) return macro;
+        return {
+          ...macro,
+          steps: macro.steps.filter((step) => step.id !== stepId),
+          updatedAt: Date.now(),
+        };
+      }),
+    );
+  }, []);
+
+  const moveStep = useCallback<MacroContextType['moveStep']>((macroId, fromIndex, toIndex) => {
+    setMacros((prev) =>
+      prev.map((macro) => {
+        if (macro.id !== macroId) return macro;
+        const steps = [...macro.steps];
+        if (fromIndex < 0 || fromIndex >= steps.length || toIndex < 0 || toIndex >= steps.length) {
+          return macro;
+        }
+        const [item] = steps.splice(fromIndex, 1);
+        steps.splice(toIndex, 0, item);
+        return {
+          ...macro,
+          steps,
+          updatedAt: Date.now(),
+        };
+      }),
+    );
+  }, []);
+
+  const waitFor = useCallback((ms: number) => {
+    if (ms <= 0) return Promise.resolve();
+    return new Promise<void>((resolve) => {
+      const timer = setTimeout(() => {
+        const signal = stopSignalRef.current;
+        signal.timer = null;
+        signal.wake = null;
+        resolve();
+      }, ms);
+      const signal = stopSignalRef.current;
+      signal.timer = timer;
+      signal.wake = resolve;
+    });
+  }, []);
+
+  const stopMacro = useCallback(() => {
+    const signal = stopSignalRef.current;
+    if (!runtimeRef.current.runningId) {
+      setStopRequested(false);
+      return;
+    }
+    if (!signal.shouldStop) {
+      addCommand('Macro stop requested');
+    }
+    signal.shouldStop = true;
+    setStopRequested(true);
+    if (signal.timer) {
+      clearTimeout(signal.timer);
+      signal.timer = null;
+    }
+    if (signal.wake) {
+      signal.wake();
+      signal.wake = null;
+    }
+  }, [addCommand]);
+
+  const runMacro = useCallback<MacroContextType['runMacro']>(
+    async (id) => {
+      const macro = macros.find((m) => m.id === id);
+      if (!macro) {
+        throw new Error('Macro not found');
+      }
+      if (runtimeRef.current.runningId && runtimeRef.current.runningId !== id) {
+        const message = 'Another macro is already running';
+        addCommand(message);
+        throw new Error(message);
+      }
+      if (macro.steps.length === 0) {
+        addCommand(`Macro "${macro.name}" has no steps to run`);
+        return;
+      }
+
+      stopSignalRef.current.shouldStop = false;
+      stopSignalRef.current.wake = null;
+      setStopRequested(false);
+
+      addCommand(`Macro "${macro.name}" starting (${macro.steps.length} steps)`);
+      setRuntime({ runningId: id, stepIndex: -1, startedAt: Date.now() });
+
+      for (let index = 0; index < macro.steps.length; index += 1) {
+        if (stopSignalRef.current.shouldStop) break;
+        const step = macro.steps[index];
+        setRuntime((prev) => ({ ...prev, stepIndex: index }));
+        addCommand(
+          `Macro step ${index + 1}/${macro.steps.length}: ${step.label || step.command}`,
+        );
+
+        try {
+          sendCommand(step.command, step.payload);
+        } catch (error) {
+          console.error('[MacroProvider] Failed to send command', error);
+          addCommand(`Macro command failed: ${step.command}`);
+        }
+
+        if (stopSignalRef.current.shouldStop) break;
+        const delay = Math.max(0, step.delayMs ?? 0);
+        await waitFor(delay);
+      }
+
+      const wasStopped = stopSignalRef.current.shouldStop;
+      const macroName = macro.name || 'Macro';
+
+      stopSignalRef.current.shouldStop = false;
+      if (stopSignalRef.current.timer) {
+        clearTimeout(stopSignalRef.current.timer);
+        stopSignalRef.current.timer = null;
+      }
+      stopSignalRef.current.wake = null;
+
+      setRuntime({ runningId: null, stepIndex: -1, startedAt: null });
+      setStopRequested(false);
+
+      addCommand(`Macro "${macroName}" ${wasStopped ? 'stopped' : 'completed'}`);
+    },
+    [addCommand, macros, sendCommand, waitFor],
+  );
+
+  const value = useMemo<MacroContextType>(
+    () => ({
+      macros,
+      isLoaded,
+      createMacro,
+      updateMacro,
+      deleteMacro,
+      duplicateMacro,
+      addStep,
+      updateStep,
+      removeStep,
+      moveStep,
+      runMacro,
+      stopMacro,
+      runtime,
+      isRunning: runtime.runningId !== null,
+      stopRequested,
+    }),
+    [
+      addStep,
+      createMacro,
+      deleteMacro,
+      duplicateMacro,
+      isLoaded,
+      macros,
+      moveStep,
+      runMacro,
+      runtime,
+      stopMacro,
+      stopRequested,
+      updateMacro,
+      updateStep,
+      removeStep,
+    ],
+  );
+
+  return <MacroContext.Provider value={value}>{children}</MacroContext.Provider>;
+};
+

--- a/ui/robot-controller-ui/src/pages/500.tsx
+++ b/ui/robot-controller-ui/src/pages/500.tsx
@@ -25,7 +25,7 @@ export default function FiveHundred() {
           Something went wrong
         </h1>
         <p className="mt-2 text-gray-600">
-          The server encountered an error. It’s not you—it's us.
+          The server encountered an error. It’s not you—it&apos;s us.
         </p>
 
         <div className="mt-6 flex items-center justify-center gap-3">

--- a/ui/robot-controller-ui/src/pages/_app.tsx
+++ b/ui/robot-controller-ui/src/pages/_app.tsx
@@ -10,6 +10,7 @@ import React from 'react';
 import { AppProps } from 'next/app'; // Import Next.js App component props type
 import { Provider } from 'react-redux'; // Redux Provider for global state management
 import { CommandProvider } from '../context/CommandContext'; // Provides WebSocket and command state management
+import { MacroProvider } from '../context/MacroContext'; // Macro builder + automation runtime
 import store from '../redux/store'; // Redux store configuration
 import '../styles/globals.scss'; // Import global styles
 import { ErrorBoundary } from 'react-error-boundary'; // Error boundary for runtime error handling
@@ -48,9 +49,11 @@ const MyApp = ({ Component, pageProps }: AppProps) => {
   return (
     <Provider store={store}> {/* Wrap all components with Redux state management */}
       <CommandProvider> {/* Provide WebSocket and command logging functionality */}
-        <ErrorBoundary FallbackComponent={ErrorFallback}> {/* Gracefully handle runtime errors */}
-          <Component {...pageProps} /> {/* Render the current page */}
-        </ErrorBoundary>
+        <MacroProvider> {/* Persisted macro editor + runtime */}
+          <ErrorBoundary FallbackComponent={ErrorFallback}> {/* Gracefully handle runtime errors */}
+            <Component {...pageProps} /> {/* Render the current page */}
+          </ErrorBoundary>
+        </MacroProvider>
       </CommandProvider>
     </Provider>
   );

--- a/ui/robot-controller-ui/src/pages/index.tsx
+++ b/ui/robot-controller-ui/src/pages/index.tsx
@@ -26,6 +26,7 @@ import SensorDashboard from '../components/sensors/SensorDashboard';
 import CarControlPanel from '../components/control/CarControlPanel';
 import CameraControlPanel from '../components/control/CameraControlPanel';
 import AutonomyPanel from '../components/control/AutonomyModal';
+import MacroManager from '../components/macros/MacroManager';
 import { useCommand } from '../context/CommandContext';
 import { COMMAND } from '../control_definitions';
 import Header from '../components/Header';
@@ -383,7 +384,8 @@ export default function Home() {
           </div>
         </div>
 
-        <div className="flex flex-col items-center space-y-4 mt-4">
+        <div className="flex flex-col items-center space-y-6 mt-6">
+          <MacroManager />
           <CommandLog />
         </div>
       </main>


### PR DESCRIPTION
## Summary
- add a MacroProvider context that persists macros, replays steps through the command WebSocket, and exposes runtime status
- build MacroManager and MacroEditor UIs for creating, duplicating, and editing macro steps with JSON payload validation
- integrate the macro workspace into the home page, surface curated command options, and tidy the 500 error copy

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc59847bd483329cde6ac274696563