### PR TITLE
Add straight-drive assist controls

### DIFF
--- a/servers/robot-controller-backend/movement/__init__.py
+++ b/servers/robot-controller-backend/movement/__init__.py
@@ -1,0 +1,3 @@
+"""Movement control helpers for the robot backend."""
+
+__all__ = []

--- a/servers/robot-controller-backend/movement/straight_drive_assist.py
+++ b/servers/robot-controller-backend/movement/straight_drive_assist.py
@@ -1,0 +1,144 @@
+"""Utility for keeping the robot driving in a straight line.
+
+The helper tracks left/right trim offsets that are applied to the motor
+controller in order to compensate for mechanical differences between wheels.
+It exposes small convenience methods so higher-level components (such as the
+WebSocket server) can enable/disable the assist feature or nudge the
+compensation in response to observed drift.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Dict, Optional
+
+DEFAULT_STEP = 25
+DEFAULT_MAX_TRIM = 800
+ABSOLUTE_MAX_TRIM = 4095
+
+
+class StraightDriveAssist:
+    """Maintain trim offsets that help the robot drive straight."""
+
+    def __init__(self, motor: Any, *, enabled: bool = True, step: int = DEFAULT_STEP,
+                 max_trim: int = DEFAULT_MAX_TRIM) -> None:
+        self.motor = motor
+        self.enabled = bool(enabled)
+        self.step = self._sanitize_positive(step, fallback=DEFAULT_STEP)
+        self.max_trim = self._sanitize_positive(max_trim, fallback=DEFAULT_MAX_TRIM)
+        self.left_trim = 0
+        self.right_trim = 0
+        self._supports_trim = hasattr(motor, "set_trim")
+        self._max_pwm = self._detect_max_pwm()
+        self._last_applied = 0.0
+        self._apply()
+
+    # ------------------------------------------------------------------
+    def status(self) -> Dict[str, Any]:
+        return {
+            "enabled": self.enabled,
+            "leftTrim": self.left_trim,
+            "rightTrim": self.right_trim,
+            "step": self.step,
+            "maxTrim": self.max_trim,
+            "supportsMotorTrim": self._supports_trim,
+            "lastApplied": self._last_applied,
+        }
+
+    # ------------------------------------------------------------------
+    def set_enabled(self, enabled: bool) -> Dict[str, Any]:
+        self.enabled = bool(enabled)
+        self._apply()
+        return self.status()
+
+    def set_step(self, value: int) -> Dict[str, Any]:
+        self.step = self._sanitize_positive(value, fallback=self.step)
+        return self.status()
+
+    def set_max_trim(self, value: int) -> Dict[str, Any]:
+        self.max_trim = self._sanitize_positive(value, fallback=self.max_trim)
+        self.left_trim = self._clamp(self.left_trim)
+        self.right_trim = self._clamp(self.right_trim)
+        self._apply()
+        return self.status()
+
+    def set_trim(self, *, left: Optional[int] = None, right: Optional[int] = None) -> Dict[str, Any]:
+        if left is not None:
+            self.left_trim = self._clamp(int(left))
+        if right is not None:
+            self.right_trim = self._clamp(int(right))
+        self._apply()
+        return self.status()
+
+    def reset(self) -> Dict[str, Any]:
+        self.left_trim = 0
+        self.right_trim = 0
+        self._apply()
+        return self.status()
+
+    def nudge(self, direction: str, amount: Optional[int] = None) -> Dict[str, Any]:
+        if not direction:
+            raise ValueError("direction is required")
+        step = self._sanitize_positive(amount if amount is not None else self.step,
+                                       fallback=self.step)
+        token = direction.strip().lower()
+        if token in {"left", "l"}:
+            # Robot veers left -> speed up right side
+            self.right_trim = self._clamp(self.right_trim + step)
+        elif token in {"right", "r"}:
+            # Robot veers right -> speed up left side
+            self.left_trim = self._clamp(self.left_trim + step)
+        elif token in {"center", "straight", "none", "neutral", "balance"}:
+            self.left_trim = self._relax(self.left_trim, step)
+            self.right_trim = self._relax(self.right_trim, step)
+        elif token in {"reset", "zero"}:
+            return self.reset()
+        else:
+            raise ValueError(f"unknown direction '{direction}'")
+        self._apply()
+        return self.status()
+
+    # ------------------------------------------------------------------
+    def _apply(self) -> None:
+        self._last_applied = time.time()
+        left = self.left_trim if self.enabled else 0
+        right = self.right_trim if self.enabled else 0
+        if self._supports_trim:
+            try:
+                self.motor.set_trim(left=left, right=right)
+            except TypeError:
+                self.motor.set_trim(left, right)  # type: ignore[call-arg]
+        else:
+            if hasattr(self.motor, "left_trim"):
+                setattr(self.motor, "left_trim", left)
+            if hasattr(self.motor, "right_trim"):
+                setattr(self.motor, "right_trim", right)
+
+    def _relax(self, value: int, amount: int) -> int:
+        if value > 0:
+            return max(0, value - amount)
+        if value < 0:
+            return min(0, value + amount)
+        return 0
+
+    def _clamp(self, value: int) -> int:
+        limit = min(self.max_trim, self._max_pwm)
+        return max(-limit, min(limit, int(value)))
+
+    def _detect_max_pwm(self) -> int:
+        for attr in ("MAX_PWM", "max_pwm", "maxSpeed", "max_speed"):
+            candidate = getattr(self.motor, attr, None)
+            if isinstance(candidate, (int, float)) and candidate > 0:
+                return int(min(candidate, ABSOLUTE_MAX_TRIM))
+        return ABSOLUTE_MAX_TRIM
+
+    @staticmethod
+    def _sanitize_positive(value: Optional[int], *, fallback: int) -> int:
+        try:
+            ivalue = int(value) if value is not None else int(fallback)
+        except Exception:
+            ivalue = int(fallback)
+        return max(1, abs(ivalue))
+
+
+__all__ = ["StraightDriveAssist"]

--- a/servers/robot-controller-backend/tests/unit/movement/test_minimal_motor_control.py
+++ b/servers/robot-controller-backend/tests/unit/movement/test_minimal_motor_control.py
@@ -1,0 +1,85 @@
+import importlib
+import os
+import sys
+import types
+
+import pytest
+
+BACKEND_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../.."))
+if BACKEND_ROOT not in sys.path:
+    sys.path.insert(0, BACKEND_ROOT)
+
+
+@pytest.fixture()
+def motor_module(monkeypatch):
+    instances = []
+
+    class FakePCA9685:
+        def __init__(self, *args, **kwargs):
+            self.calls = []
+            self.freq = None
+            instances.append(self)
+
+        def setPWMFreq(self, freq):
+            self.freq = freq
+
+        def setMotorPwm(self, channel, duty):
+            self.calls.append((channel, duty))
+
+    fake_module = types.ModuleType("PCA9685")
+    fake_module.PCA9685 = FakePCA9685
+    monkeypatch.setitem(sys.modules, "PCA9685", fake_module)
+    sys.modules.pop("movement.minimal_motor_control", None)
+    module = importlib.import_module("movement.minimal_motor_control")
+    return module, instances
+
+
+def test_forward_uses_trim_offsets(motor_module):
+    module, instances = motor_module
+    motor = module.Motor()
+    pwm = instances[0]
+
+    motor.set_trim(left=100, right=200)
+    motor.forward(1000)
+
+    # Forward motion should bias left/right channels according to trim
+    assert pwm.calls == [
+        (0, 1100), (1, 0),
+        (4, 1100), (5, 0),
+        (2, 1200), (3, 0),
+        (6, 1200), (7, 0),
+    ]
+
+
+def test_backward_respects_trim_and_clamps(motor_module):
+    module, instances = motor_module
+    motor = module.Motor()
+    pwm = instances[0]
+
+    motor.set_trim(left=5000, right=50)  # left should clamp to MAX_PWM
+    assert motor.get_trim()["left"] == motor.MAX_PWM
+
+    motor.backward(1000)
+    assert pwm.calls[-8:] == [
+        (0, 0), (1, motor.MAX_PWM),
+        (4, 0), (5, motor.MAX_PWM),
+        (2, 0), (3, 1050),
+        (6, 0), (7, 1050),
+    ]
+
+
+def test_stop_command_zeroes_channels(motor_module):
+    module, instances = motor_module
+    motor = module.Motor()
+    pwm = instances[0]
+
+    motor.forward(800)
+    motor.stop()
+
+    # Last 8 calls correspond to stop command
+    assert pwm.calls[-8:] == [
+        (0, 0), (1, 0),
+        (4, 0), (5, 0),
+        (2, 0), (3, 0),
+        (6, 0), (7, 0),
+    ]

--- a/servers/robot-controller-backend/tests/unit/movement/test_straight_drive_assist.py
+++ b/servers/robot-controller-backend/tests/unit/movement/test_straight_drive_assist.py
@@ -1,0 +1,105 @@
+import math
+import os
+import sys
+
+import pytest
+
+BACKEND_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../.."))
+if BACKEND_ROOT not in sys.path:
+    sys.path.insert(0, BACKEND_ROOT)
+
+from movement.straight_drive_assist import StraightDriveAssist
+
+
+class FakeMotor:
+    MAX_PWM = 4095
+
+    def __init__(self):
+        self.calls = []
+        self.left_trim = None
+        self.right_trim = None
+
+    def set_trim(self, left=0, right=0):
+        self.left_trim = left
+        self.right_trim = right
+        self.calls.append((left, right))
+
+
+def test_initialisation_applies_zero_trim():
+    motor = FakeMotor()
+    assist = StraightDriveAssist(motor)
+
+    status = assist.status()
+    assert status["enabled"] is True
+    assert status["leftTrim"] == 0
+    assert status["rightTrim"] == 0
+    assert motor.calls[-1] == (0, 0)
+    assert math.isclose(status["lastApplied"], assist.status()["lastApplied"], rel_tol=1e-6)
+
+
+def test_trim_configuration_and_enable_toggle():
+    motor = FakeMotor()
+    assist = StraightDriveAssist(motor)
+
+    assist.set_trim(left=150, right=20)
+    assert motor.calls[-1] == (150, 20)
+
+    assist.set_enabled(False)
+    # When disabled, trim is applied as zeros but stored internally
+    assert motor.calls[-1] == (0, 0)
+
+    assist.set_enabled(True)
+    assert motor.calls[-1] == (150, 20)
+    status = assist.status()
+    assert status["leftTrim"] == 150
+    assert status["rightTrim"] == 20
+
+
+def test_nudge_logic_and_relaxation():
+    motor = FakeMotor()
+    assist = StraightDriveAssist(motor, step=50, max_trim=100)
+
+    status = assist.nudge("left")
+    assert status["rightTrim"] == 50
+    assert status["leftTrim"] == 0
+
+    status = assist.nudge("right", amount=40)
+    assert status["leftTrim"] == 40
+    assert status["rightTrim"] == 50
+
+    status = assist.nudge("center", amount=30)
+    assert status["leftTrim"] == 10
+    assert status["rightTrim"] == 20
+
+    status = assist.nudge("reset")
+    assert status["leftTrim"] == 0
+    assert status["rightTrim"] == 0
+
+
+def test_max_trim_clamps_values():
+    motor = FakeMotor()
+    assist = StraightDriveAssist(motor)
+
+    assist.set_trim(left=2000, right=2000)
+    status = assist.set_max_trim(100)
+    assert status["leftTrim"] == 100
+    assert status["rightTrim"] == 100
+
+
+def test_invalid_direction_raises_value_error():
+    motor = FakeMotor()
+    assist = StraightDriveAssist(motor)
+
+    with pytest.raises(ValueError):
+        assist.nudge("diagonal")
+
+
+def test_set_step_updates_step_size():
+    motor = FakeMotor()
+    assist = StraightDriveAssist(motor)
+    assist.set_step(80)
+    assert assist.status()["step"] == 80
+
+    # Negative values should be normalised to positive
+    assist.set_step(-30)
+    assert assist.status()["step"] == 30


### PR DESCRIPTION
## Summary
- add trim controls to the minimal motor controller so forward/backward motion can be balanced
- introduce a straight-drive assist helper and expose WebSocket commands to configure or nudge trims remotely
- cover the new behaviour with movement unit tests for both the helper and motor trim logic

## Testing
- pytest servers/robot-controller-backend/tests/unit/movement -q

------
https://chatgpt.com/codex/tasks/task_e_68cc5e1430e88332a9da111535b656da