### PR TITLE
Add autonomy backend alias and tests for modal compatibility

### DIFF
--- a/servers/robot-controller-backend/autonomy/controller.py
+++ b/servers/robot-controller-backend/autonomy/controller.py
@@ -32,11 +32,17 @@ __all__ = [
 ModeFactory = Callable[..., AutonomyModeHandler]
 
 
+# Backwards compatibility aliases for legacy mode names used by older UIs.
+_MODE_ALIASES = {
+    "line_track": "line_follow",
+}
+
+
 def _canonical_name(name: str) -> str:
-    cleaned = (name or "").strip().lower().replace("-", "_")
+    cleaned = (name or "").strip().lower().replace("-", "_").replace(" ", "_")
     if not cleaned:
         raise AutonomyError("mode name is empty")
-    return cleaned
+    return _MODE_ALIASES.get(cleaned, cleaned)
 
 
 @dataclass(slots=True)

--- a/servers/robot-controller-backend/tests/unit/api/test_autonomy_routes.py
+++ b/servers/robot-controller-backend/tests/unit/api/test_autonomy_routes.py
@@ -1,10 +1,17 @@
 from __future__ import annotations
 
 import asyncio
+import sys
+from pathlib import Path
 
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
 
 from api.autonomy_routes import controller, router
 
@@ -93,3 +100,70 @@ def test_invalid_mode_returns_400(client: TestClient):
     res = client.post("/autonomy/start", json={"mode": "", "params": {}})
     assert res.status_code == 400
     assert res.json()["detail"]
+
+
+def test_start_accepts_legacy_line_track_name(client: TestClient):
+    res = client.post("/autonomy/start", json={"mode": "line_track", "params": {}})
+    assert res.status_code == 200
+    body = res.json()
+    assert body["status"] == "ok"
+    assert body["autonomy"]["mode"] == "line_follow"
+
+
+def test_modal_parameters_roundtrip(client: TestClient):
+    modal_params = {
+        "speedPct": 37,
+        "aggressiveness": 82,
+        "obstacleAvoidance": True,
+        "laneKeeping": False,
+        "headlights": True,
+        "avoidStopDistM": 0.35,
+        "line_kP": 1.25,
+        "searchYawRate": 45,
+        "hsvLow": [5, 120, 110],
+        "hsvHigh": [15, 240, 250],
+        "minArea": 450,
+        "maxArea": 18000,
+        "priorities": ["safety", "vision", "waypoints"],
+        "gridEnabled": True,
+        "gridCellSizeM": 0.2,
+        "gridDecay": 0.05,
+        "batteryMinPct": 18,
+    }
+
+    res = client.post("/autonomy/start", json={"mode": "patrol", "params": modal_params})
+    assert res.status_code == 200
+    body = res.json()
+    params = body["autonomy"]["params"]
+
+    assert params["speedPct"] == modal_params["speedPct"]
+    assert params["aggressiveness"] == modal_params["aggressiveness"]
+    assert params["obstacleAvoidance"] is modal_params["obstacleAvoidance"]
+    assert params["laneKeeping"] is modal_params["laneKeeping"]
+    assert params["headlights"] is modal_params["headlights"]
+    assert params["priorities"] == modal_params["priorities"]
+    assert params["hsvLow"] == modal_params["hsvLow"]
+    assert params["hsvHigh"] == modal_params["hsvHigh"]
+    assert params["minArea"] == modal_params["minArea"]
+    assert params["maxArea"] == modal_params["maxArea"]
+    assert params["gridEnabled"] is True
+    assert params["batteryMinPct"] == modal_params["batteryMinPct"]
+    assert params["gridCellSizeM"] == pytest.approx(modal_params["gridCellSizeM"])
+    assert params["gridDecay"] == pytest.approx(modal_params["gridDecay"])
+    assert params["avoidStopDistM"] == pytest.approx(modal_params["avoidStopDistM"])
+    assert params["line_kP"] == pytest.approx(modal_params["line_kP"])
+    assert params["searchYawRate"] == modal_params["searchYawRate"]
+
+    res = client.post("/autonomy/update", json={
+        "params": {
+            "gridEnabled": False,
+            "priorities": ["vision", "edge", "safety"],
+            "hsvLow": [10, 200, 210],
+        },
+    })
+    assert res.status_code == 200
+    updated = res.json()["autonomy"]["params"]
+    assert updated["gridEnabled"] is False
+    assert updated["priorities"] == ["vision", "edge", "safety"]
+    assert updated["hsvLow"] == [10, 200, 210]
+    assert updated["speedPct"] == modal_params["speedPct"]


### PR DESCRIPTION
## Summary
- add a legacy mode alias in the autonomy controller so `line_track` requests resolve to `line_follow`
- fix the API test harness import path and expand coverage for the autonomy modal parameter flows

## Testing
- pytest tests/unit/api/test_autonomy_routes.py

------
https://chatgpt.com/codex/tasks/task_e_68cc91e89cd4833292c7f0aa2d43b557