### PR TITLE
Add music reactive lighting pattern

### DIFF
--- a/servers/robot-controller-backend/README.md
+++ b/servers/robot-controller-backend/README.md
@@ -74,6 +74,10 @@ go run sensors/main_ultrasonic.go
 - WebSocket server written in Go that forwards lighting commands to the privileged
   `run_led.sh` wrapper, which in turn executes the Python LED controller.
 - Supports colour hex strings or integers, brightness, and pattern/mode selection.
+- Includes a music-reactive pattern (`pattern: "music"`) that samples the default
+  microphone when `sounddevice` is installed. The controller automatically falls back
+  to a synthetic beat when audio input is unavailable so the animation still runs in
+  development containers.
 - Responds to heartbeat `{ "type": "ping" }` frames with `{ "type": "pong" }`.
 - Ensure `RUN_LED` inside the Go file points at the correct absolute path and that the
   wrapper can run with the required permissions (often via `sudo`).

--- a/servers/robot-controller-backend/controllers/lighting/led_control.py
+++ b/servers/robot-controller-backend/controllers/lighting/led_control.py
@@ -19,6 +19,8 @@ import sys
 import time
 from rpi_ws281x import Adafruit_NeoPixel, Color, WS2811_STRIP_GRB
 
+from controllers.lighting.patterns import music_visualizer
+
 class LedController:
     """
     Controller class for WS2812/WS2811 LED strips using rpi_ws281x.
@@ -116,9 +118,13 @@ class LedController:
                 return
 
             # Always apply requested pattern!
-            r = int(((color >> 16) & 255) * brightness)
-            g = int(((color >> 8) & 255) * brightness)
-            b = int((color & 255) * brightness)
+            raw_r = (color >> 16) & 255
+            raw_g = (color >> 8) & 255
+            raw_b = color & 255
+
+            r = int(raw_r * brightness)
+            g = int(raw_g * brightness)
+            b = int(raw_b * brightness)
 
             if mode == "rainbow" or pattern == "rainbow":
                 self.rainbow(interval, brightness)
@@ -143,6 +149,17 @@ class LedController:
                         step_brightness = brightness * (i / 255.0)
                         self._apply_brightness(color, step_brightness)
                         time.sleep(interval / 1000 / 50)
+                self.is_on = True
+            elif pattern in ("music", "music-reactive"):
+                update_ms = interval if isinstance(interval, (int, float)) and interval > 0 else 80
+                duration = max(8.0, update_ms / 1000.0 * 80)
+                music_visualizer(
+                    self.strip,
+                    base_color=(raw_r, raw_g, raw_b),
+                    brightness=brightness,
+                    update_ms=int(update_ms),
+                    duration_s=duration,
+                )
                 self.is_on = True
             else:
                 print(f"Unknown pattern: {pattern}")

--- a/servers/robot-controller-backend/controllers/lighting/patterns.py
+++ b/servers/robot-controller-backend/controllers/lighting/patterns.py
@@ -12,7 +12,12 @@ Usage:
 - All functions assume the caller passes a pre-initialized NeoPixel strip object as the first argument.
 """
 
+import math
+import time
 from time import sleep
+from typing import Sequence, Tuple
+
+import numpy as np
 from rpi_ws281x import Color
 
 def color_wipe(strip, color):
@@ -123,5 +128,130 @@ def rainbow(strip, wait_ms=20, iterations=1):
             strip.setPixelColor(i, wheel((i + j) & 255))
         strip.show()
         sleep(wait_ms / 1000.0)
+
+# --- Advanced patterns -----------------------------------------------------
+
+def _clamp(value: float, minimum: float, maximum: float) -> float:
+    """Clamp *value* to the inclusive range [minimum, maximum]."""
+
+    return max(minimum, min(maximum, value))
+
+
+def _mix_colors(color_a: Tuple[int, int, int], color_b: Tuple[int, int, int], ratio: float) -> Tuple[int, int, int]:
+    """Blend two RGB tuples using *ratio* (0.0 → A, 1.0 → B)."""
+
+    ratio = _clamp(ratio, 0.0, 1.0)
+    return (
+        int(color_a[0] * (1.0 - ratio) + color_b[0] * ratio),
+        int(color_a[1] * (1.0 - ratio) + color_b[1] * ratio),
+        int(color_a[2] * (1.0 - ratio) + color_b[2] * ratio),
+    )
+
+
+def _color_with_scale(color: Tuple[int, int, int], scale: float) -> Color:
+    """Return an rpi_ws281x Color from an RGB tuple scaled by *scale*."""
+
+    scale = _clamp(scale, 0.0, 1.0)
+    r = int(_clamp(color[0] * scale, 0, 255))
+    g = int(_clamp(color[1] * scale, 0, 255))
+    b = int(_clamp(color[2] * scale, 0, 255))
+    return Color(r, g, b)
+
+
+def music_visualizer(
+    strip,
+    base_color: Sequence[int] = (255, 255, 255),
+    brightness: float = 1.0,
+    update_ms: int = 80,
+    duration_s: float = 8.0,
+    sample_rate: int = 44100,
+) -> None:
+    """Animate LEDs so they "dance" in response to music captured from the microphone.
+
+    The function attempts to read short frames from the default input device using
+    :mod:`sounddevice`. When the dependency or an input device is unavailable it
+    gracefully falls back to a synthetic waveform so the pattern still produces a
+    dynamic animation instead of failing outright.
+
+    Args:
+        strip: Initialised NeoPixel strip.
+        base_color: RGB triple that defines the core hue for the animation.
+        brightness: Global brightness multiplier ``0.0`` – ``1.0``.
+        update_ms: Update cadence in milliseconds (controls responsiveness).
+        duration_s: Total duration of the animation in seconds.
+        sample_rate: Sample rate used when capturing audio.
+    """
+
+    try:  # Optional dependency; fall back to synthetic data when unavailable.
+        import sounddevice as sd  # type: ignore
+    except Exception:  # pragma: no cover - absence is fine on CI/containers
+        sd = None  # type: ignore[assignment]
+
+    brightness = _clamp(float(brightness), 0.0, 1.0)
+    update_sec = max(update_ms / 1000.0, 0.05)
+    duration = max(duration_s, update_sec)
+
+    num_pixels = getattr(strip, "numPixels", lambda: 0)()
+    if num_pixels <= 0:
+        return
+
+    base = tuple(int(_clamp(c, 0, 255)) for c in base_color)
+    complement = tuple(255 - c for c in base)
+    background = tuple(int(c * 0.05) for c in base)
+
+    palette = [_mix_colors(base, complement, i / max(num_pixels - 1, 1)) for i in range(num_pixels)]
+
+    smoothing = 0.65
+    level = 0.0
+    fallback_phase = 0.0
+    offset = 0
+
+    def capture_level() -> float:
+        nonlocal sd
+
+        if sd is None:
+            return -1.0
+
+        frames = max(int(sample_rate * update_sec), 256)
+        try:
+            audio = sd.rec(frames, samplerate=sample_rate, channels=1, dtype="float32")
+            sd.wait()
+        except Exception as exc:  # pragma: no cover - depends on runtime hardware
+            print(f"Music visualizer audio capture unavailable ({exc}); using synthetic waveform.")
+            sd = None  # type: ignore[assignment]
+            return -1.0
+
+        if not len(audio):
+            return 0.0
+
+        value = float(np.sqrt(np.mean(np.square(audio))))
+        if math.isnan(value):
+            value = 0.0
+        return _clamp(value * 8.0, 0.0, 1.0)
+
+    end_time = time.time() + duration
+    while time.time() < end_time:
+        amplitude = capture_level()
+        if amplitude < 0:
+            fallback_phase += update_sec * 2.0
+            amplitude = (math.sin(fallback_phase) + 1.0) / 2.0
+
+        level = smoothing * level + (1.0 - smoothing) * amplitude
+        active_pixels = max(1, int(level * num_pixels))
+        trail = max(1, int(num_pixels * 0.15))
+
+        for idx in range(num_pixels):
+            if idx < active_pixels:
+                color = palette[(idx + offset) % num_pixels]
+                strip.setPixelColor(idx, _color_with_scale(color, brightness))
+            elif idx < active_pixels + trail:
+                fade = 1.0 - ((idx - active_pixels) / max(trail, 1))
+                strip.setPixelColor(idx, _color_with_scale(base, brightness * 0.35 * fade))
+            else:
+                strip.setPixelColor(idx, _color_with_scale(background, brightness))
+
+        strip.show()
+        offset = (offset + 1) % num_pixels
+        time.sleep(update_sec)
 
 # Lighting patterns for NeoPixels

--- a/servers/robot-controller-backend/requirements.txt
+++ b/servers/robot-controller-backend/requirements.txt
@@ -69,6 +69,13 @@ requests==2.31.0
 rich==13.7.1
 
 ############################
+# Audio reactive lighting  #
+############################
+
+# Captures microphone audio for the music-reactive LED pattern. Optional on dev machines.
+sounddevice==0.4.6
+
+############################
 # Testing                  #
 ############################
 

--- a/ui/robot-controller-ui/README.md
+++ b/ui/robot-controller-ui/README.md
@@ -12,6 +12,8 @@ talks to the backend via WebSockets, REST APIs, and the gateway proxy.
 - Live MJPEG video feed with placeholder frames and health polling.
 - Lighting composer with colour selection, pattern/mode controls, and brightness
   sliders.
+- Music-reactive lighting mode that listens for microphone audio (with a graceful
+  fallback when no input device is present).
 - Sensor dashboards for ultrasonic distance, line tracker state, and GPS data.
 - Autonomy modal for starting/stopping modes exposed by the backend controller.
 - Header service bar showing link health and gateway profile, backed by REST/WS checks.

--- a/ui/robot-controller-ui/src/components/lighting/LedControl.tsx
+++ b/ui/robot-controller-ui/src/components/lighting/LedControl.tsx
@@ -37,8 +37,14 @@ const LedControl: React.FC<LedControlProps> = ({ sendCommand }) => {
     setMode(event.target.value as LightingMode);
 
   // Pattern change handler
-  const handlePatternChange = (event: React.ChangeEvent<HTMLSelectElement>) =>
-    setPattern(event.target.value as LightingPattern);
+  const handlePatternChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    const nextPattern = event.target.value as LightingPattern;
+    setPattern(nextPattern);
+
+    if (nextPattern === 'music' && interval > 250) {
+      setInterval(120);
+    }
+  };
 
   // Interval change handler
   const handleIntervalChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -120,6 +126,12 @@ const LedControl: React.FC<LedControlProps> = ({ sendCommand }) => {
               </option>
             ))}
           </select>
+          {pattern === 'music' && (
+            <p className="mt-2 text-sm text-green-200">
+              Music mode listens to the default microphone when available and animates the
+              LEDs to the beat. Lower interval values make the effect more responsive.
+            </p>
+          )}
         </div>
 
         {/* Interval Input (only for dynamic patterns) */}

--- a/ui/robot-controller-ui/src/components/lighting/LedModal.tsx
+++ b/ui/robot-controller-ui/src/components/lighting/LedModal.tsx
@@ -14,7 +14,7 @@ import { SketchPicker } from 'react-color';
 import { connectLightingWs } from '../../utils/connectLightingWs';
 
 const LIGHTING_MODES = ['single', 'rainbow'] as const;
-const LIGHTING_PATTERNS = ['static', 'pulse', 'blink'] as const;
+const LIGHTING_PATTERNS = ['static', 'pulse', 'blink', 'music'] as const;
 
 type LightingMode = (typeof LIGHTING_MODES)[number];
 type LightingPattern = (typeof LIGHTING_PATTERNS)[number];
@@ -204,8 +204,14 @@ const LedModal: React.FC<LedModalProps> = ({ isOpen, onClose }) => {
   const handleColor1Change = (color: ColorResult) => setColor1(color.hex);
   const handleModeChange = (e: React.ChangeEvent<HTMLSelectElement>) =>
     setMode(e.target.value as LightingMode);
-  const handlePatternChange = (e: React.ChangeEvent<HTMLSelectElement>) =>
-    setPattern(e.target.value as LightingPattern);
+  const handlePatternChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const nextPattern = e.target.value as LightingPattern;
+    setPattern(nextPattern);
+
+    if (nextPattern === 'music' && intervalMs > 250) {
+      setIntervalMs(120);
+    }
+  };
   const handleIntervalChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = Number(e.target.value);
     setIntervalMs(Number.isFinite(value) ? Math.max(100, Math.floor(value)) : 100);
@@ -289,6 +295,11 @@ const LedModal: React.FC<LedModalProps> = ({ isOpen, onClose }) => {
       : serverStatus === 'connecting'
       ? 'Connecting…'
       : 'Disconnected';
+
+  const intervalConfig =
+    pattern === 'music'
+      ? { min: 50, step: 10 }
+      : { min: 100, step: 50 };
 
   if (!isOpen) return null;
 
@@ -391,6 +402,12 @@ const LedModal: React.FC<LedModalProps> = ({ isOpen, onClose }) => {
                 </option>
               ))}
             </select>
+            {pattern === 'music' && (
+              <p className="mt-2 text-sm text-green-200">
+                Music mode listens to the default microphone when available and generates a
+                beat-reactive light show. Reduce the interval for faster reaction times.
+              </p>
+            )}
           </div>
 
           {/* Interval Input */}
@@ -405,8 +422,8 @@ const LedModal: React.FC<LedModalProps> = ({ isOpen, onClose }) => {
                 value={intervalMs}
                 onChange={handleIntervalChange}
                 className="w-full bg-gray-800 text-white p-2 rounded mt-1"
-                min={100}
-                step={50}
+                min={intervalConfig.min}
+                step={intervalConfig.step}
               />
             </div>
           )}

--- a/ui/robot-controller-ui/src/components/lighting/LightingPattern.tsx
+++ b/ui/robot-controller-ui/src/components/lighting/LightingPattern.tsx
@@ -30,7 +30,7 @@ const LightingPattern: React.FC<LightingPatternProps> = ({ onSelectPattern }) =>
   };
 
   // List of available patterns
-  const patterns = ['static', 'blink', 'fade', 'chase', 'rainbow'];
+  const patterns = ['static', 'blink', 'fade', 'chase', 'rainbow', 'music'];
 
   return (
     <div className="flex flex-wrap justify-around items-center bg-gray-900 p-4 rounded-lg shadow-md">

--- a/ui/robot-controller-ui/src/control_definitions.ts
+++ b/ui/robot-controller-ui/src/control_definitions.ts
@@ -85,6 +85,7 @@ export const LIGHTING_PATTERNS = [
   'fade',     // smooth transitions
   'chase',    // chasing effect
   'rainbow',  // spectrum sweep
+  'music',    // audio reactive pulse
 ] as const;
 
 // Lighting Mode Constants


### PR DESCRIPTION
## Summary
- add a music_visualizer LED pattern that samples microphone audio when available and falls back to synthetic beats when audio capture is missing
- extend the dispatcher and LED controller to route the new pattern, respect brightness scaling, and include the optional sounddevice dependency plus docs
- surface the music pattern in the UI with contextual guidance, responsive interval defaults, and updated documentation

## Testing
- npm run lint *(fails: dependencies that include node-canvas require system pixman headers in this container)*

------
https://chatgpt.com/codex/tasks/task_e_68cdfde1c6948332b83c0f008979769a