### PR TITLE
Add realistic backend e2e and integration tests

### DIFF
--- a/servers/robot-controller-backend/tests/e2e/test_full_system.py
+++ b/servers/robot-controller-backend/tests/e2e/test_full_system.py
@@ -1,10 +1,126 @@
+"""End-to-end tests covering the public HTTP APIs."""
 
-import unittest
+from __future__ import annotations
 
-class TestFullSystem(unittest.TestCase):
-    def test_example(self):
-        self.assertEqual(1, 1)
+import asyncio
+from typing import Iterator, List
 
-if __name__ == "__main__":
-    unittest.main()
+import pytest
+from fastapi.testclient import TestClient
 
+from api import autonomy_routes, lighting_routes
+from autonomy import build_default_controller
+from main_api import app as backend_app
+from servers.gateway_api import app as gateway_app
+
+
+@pytest.fixture
+def api_client(monkeypatch) -> Iterator[TestClient]:
+    """Provide a FastAPI test client wired up with a fresh controller."""
+
+    controller = build_default_controller()
+    monkeypatch.setattr(autonomy_routes, "controller", controller)
+    with TestClient(backend_app) as client:
+        yield client
+    asyncio.run(controller.stop())
+
+
+@pytest.fixture
+def gateway_client() -> Iterator[TestClient]:
+    with TestClient(gateway_app) as client:
+        yield client
+
+
+def test_autonomy_flow_end_to_end(api_client: TestClient) -> None:
+    status = api_client.get("/autonomy/status")
+    assert status.status_code == 200
+    payload = status.json()
+    assert payload["status"] == "ok"
+    autonomy = payload["autonomy"]
+    assert autonomy["active"] is False
+    assert "patrol" in autonomy["availableModes"]
+
+    start = api_client.post("/autonomy/start", json={"mode": "patrol", "params": {"speed": 1}})
+    assert start.status_code == 200
+    autonomy = start.json()["autonomy"]
+    assert autonomy["active"] is True
+    assert autonomy["mode"] == "patrol"
+    assert autonomy["params"]["speed"] == 1
+
+    updated = api_client.post("/autonomy/update", json={"params": {"speed": 3}})
+    assert updated.status_code == 200
+    assert updated.json()["autonomy"]["params"]["speed"] == 3
+
+    docked = api_client.post("/autonomy/dock")
+    assert docked.status_code == 200
+    assert docked.json()["autonomy"]["mode"] == "dock"
+
+    stopped = api_client.post("/autonomy/stop")
+    assert stopped.status_code == 200
+    stop_state = stopped.json()["autonomy"]
+    assert stop_state["active"] is False
+    assert stop_state["mode"] == "idle"
+
+
+def test_autonomy_waypoint_round_trip(api_client: TestClient) -> None:
+    start = api_client.post("/autonomy/start", json={"mode": "waypoints", "params": {"speed": 0.5}})
+    assert start.status_code == 200
+
+    response = api_client.post(
+        "/autonomy/set_waypoint",
+        json={"label": "Base", "lat": 41.5, "lon": -71.2},
+    )
+    assert response.status_code == 200
+    waypoint = response.json()["autonomy"]["params"]["lastWaypoint"]
+    assert waypoint["label"] == "Base"
+    assert waypoint["lat"] == pytest.approx(41.5)
+    assert waypoint["lon"] == pytest.approx(-71.2)
+    assert waypoint["ts"] >= response.json()["autonomy"]["startedAt"]
+
+
+def test_lighting_routes_invoke_subprocess(api_client: TestClient, monkeypatch) -> None:
+    calls: List[List[str]] = []
+
+    def fake_run(cmd: List[str], check: bool = True) -> None:
+        calls.append(cmd)
+
+    monkeypatch.setattr(lighting_routes.subprocess, "run", fake_run)
+
+    on = api_client.get("/lighting/light/on")
+    off = api_client.get("/lighting/light/off")
+
+    assert on.status_code == 200
+    assert off.status_code == 200
+    assert on.json()["status"] == "success"
+    assert off.json()["status"] == "success"
+    assert calls[0][:2] == ["python3", "controllers/lighting/led_control.py"]
+    assert calls[0][-1] == "--on"
+    assert calls[1][-1] == "--off"
+
+
+def test_gateway_health_and_network_endpoints(gateway_client: TestClient) -> None:
+    health = gateway_client.get("/health")
+    assert health.status_code == 200
+    assert health.text == "ok"
+
+    summary = gateway_client.get("/api/net/summary")
+    assert summary.status_code == 200
+    payload = summary.json()
+    assert payload["online"] is True
+    assert payload["ssid"]
+
+    wifi = gateway_client.post("/api/net/wifi/connect", json={"ssid": "TestNet"})
+    assert wifi.status_code == 200
+    assert "TestNet" in wifi.json()["message"]
+
+    pan = gateway_client.post("/api/net/pan/connect", json={})
+    assert pan.status_code == 200
+    assert "PAN" in pan.json()["message"]
+
+
+def test_gateway_video_feed_stream_produces_chunks(gateway_client: TestClient) -> None:
+    with gateway_client.stream("GET", "/video_feed") as response:
+        assert response.status_code == 200
+        assert "multipart/x-mixed-replace" in response.headers["content-type"]
+        chunk = next(response.iter_bytes())
+        assert b"--frame" in chunk

--- a/servers/robot-controller-backend/tests/integration/test_command_integration.py
+++ b/servers/robot-controller-backend/tests/integration/test_command_integration.py
@@ -1,10 +1,100 @@
+"""Integration tests exercising the autonomy controller workflow."""
 
-import unittest
+from __future__ import annotations
 
-class TestCommandIntegration(unittest.TestCase):
-    def test_example(self):
-        self.assertEqual(1, 1)
+import asyncio
+from typing import Awaitable, Callable
 
-if __name__ == "__main__":
-    unittest.main()
+import pytest
 
+from autonomy import AutonomyController, AutonomyError, build_default_controller
+
+ControllerTest = Callable[[AutonomyController], Awaitable[None]]
+
+
+def run_controller_test(test: ControllerTest) -> None:
+    """Helper that provisions a fresh controller for every test case."""
+
+    async def _wrapper() -> None:
+        controller = build_default_controller()
+        try:
+            await test(controller)
+        finally:
+            # Ensure we always stop the session even if the assertion fails so the
+            # global state is clean for the next scenario.
+            await controller.stop()
+
+    asyncio.run(_wrapper())
+
+
+def test_start_update_and_stop_cycle() -> None:
+    async def scenario(controller: AutonomyController) -> None:
+        status = await controller.start("patrol", {"speed": 1})
+        assert status["active"] is True
+        assert status["mode"] == "patrol"
+        assert status["params"]["speed"] == 1
+
+        status = await controller.update({"speed": 2})
+        assert status["params"]["speed"] == 2
+
+        status = await controller.stop()
+        assert status["active"] is False
+        assert status["mode"] == "idle"
+        assert status["params"] == {}
+
+    run_controller_test(scenario)
+
+
+def test_dock_switches_modes_and_confirms() -> None:
+    async def scenario(controller: AutonomyController) -> None:
+        await controller.start("patrol", {})
+        status = await controller.dock()
+        assert status["active"] is True
+        assert status["mode"] == "dock"
+        assert status["handler"] == "DockMode"
+
+        # Issuing dock again should hit the active handler rather than
+        # instantiating a new one, keeping the mode stable.
+        status = await controller.dock()
+        assert status["mode"] == "dock"
+        assert status["handler"] == "DockMode"
+
+    run_controller_test(scenario)
+
+
+def test_waypoint_updates_are_tracked() -> None:
+    async def scenario(controller: AutonomyController) -> None:
+        await controller.start("waypoints", {"speed": 0.25})
+        status = await controller.set_waypoint("Home", 41.5, -71.2)
+        waypoint = status["params"]["lastWaypoint"]
+        assert waypoint["label"] == "Home"
+        assert waypoint["lat"] == pytest.approx(41.5)
+        assert waypoint["lon"] == pytest.approx(-71.2)
+        assert waypoint["ts"] >= status["startedAt"]
+
+    run_controller_test(scenario)
+
+
+def test_alias_names_are_normalised() -> None:
+    async def scenario(controller: AutonomyController) -> None:
+        status = await controller.start("Line Track", {})
+        assert status["mode"] == "line_follow"
+
+    run_controller_test(scenario)
+
+
+def test_invalid_parameter_payloads_raise_errors() -> None:
+    async def scenario(controller: AutonomyController) -> None:
+        await controller.start("patrol", {})
+        with pytest.raises(AutonomyError, match="params must be a mapping"):
+            await controller.update(["not", "a", "mapping"])  # type: ignore[list-item]
+
+    run_controller_test(scenario)
+
+
+def test_waypoint_requires_active_session() -> None:
+    async def scenario(controller: AutonomyController) -> None:
+        with pytest.raises(AutonomyError, match="no autonomy mode is active"):
+            await controller.set_waypoint("Home", 1.0, 2.0)
+
+    run_controller_test(scenario)

--- a/servers/robot-controller-backend/tests/unit/test_command_processor.py
+++ b/servers/robot-controller-backend/tests/unit/test_command_processor.py
@@ -1,10 +1,72 @@
+"""Unit tests covering the autonomy mode registry and controller edge-cases."""
 
-import unittest
+from __future__ import annotations
 
-class TestCommandProcessor(unittest.TestCase):
-    def test_example(self):
-        self.assertEqual(1, 1)
+import asyncio
+import logging
+from typing import Dict
 
-if __name__ == "__main__":
-    unittest.main()
+import pytest
 
+from autonomy import AutonomyController, AutonomyError
+from autonomy.base import AutonomyModeHandler
+from autonomy.controller import ModeRegistry
+
+
+class DummyMode(AutonomyModeHandler):
+    def __init__(self, name: str = "dummy", *, logger: logging.Logger | None = None) -> None:
+        super().__init__(name, logger=logger)
+        self.started_with: Dict[str, object] | None = None
+
+    async def start(self, params):  # type: ignore[override]
+        self.started_with = dict(params)
+
+
+def test_register_requires_callable() -> None:
+    registry = ModeRegistry()
+    with pytest.raises(TypeError):
+        registry.register("demo", object())  # type: ignore[arg-type]
+
+
+def test_registry_resolves_aliases_and_context() -> None:
+    registry = ModeRegistry()
+    captured: Dict[str, object] = {}
+
+    def factory(*, context, logger):
+        mode = DummyMode("line_follow", logger=logger)
+        captured.update(context)
+        return mode
+
+    registry.register("line_follow", factory)
+    handler = registry.create("Line Track", context={"port": 9000}, logger=logging.getLogger("test"))
+
+    assert isinstance(handler, DummyMode)
+    assert handler.name == "line_follow"
+    assert captured == {"port": 9000}
+
+
+def test_registry_rejects_unknown_modes() -> None:
+    registry = ModeRegistry()
+    with pytest.raises(AutonomyError, match="unknown autonomy mode"):
+        registry.create("missing", context={}, logger=logging.getLogger("test"))
+
+
+def test_controller_start_unknown_mode_raises() -> None:
+    async def scenario() -> None:
+        controller = AutonomyController()
+        with pytest.raises(AutonomyError, match="unknown autonomy mode"):
+            await controller.start("missing", {})
+
+    asyncio.run(scenario())
+
+
+def test_controller_start_uses_registry_factory() -> None:
+    async def scenario() -> None:
+        registry = ModeRegistry()
+        registry.register("demo", lambda **kw: DummyMode("demo", logger=kw.get("logger")))
+        controller = AutonomyController(registry)
+        status = await controller.start("demo", {"speed": 1})
+        assert status["mode"] == "demo"
+        assert status["params"]["speed"] == 1
+
+    asyncio.run(scenario())


### PR DESCRIPTION
## Summary
- replace the placeholder integration suite with real AutonomyController coverage for start/update/stop, docking and waypoint flows
- add FastAPI end-to-end tests that exercise the autonomy routes, lighting endpoints and gateway health/video handlers
- harden unit coverage around the autonomy mode registry by checking alias resolution, error handling and factory usage

## Testing
- python3 -m pytest *(fails: existing backend tests cannot be collected because of unrelated import issues in controllers/lighting and hardware-dependent suites)*

------
https://chatgpt.com/codex/tasks/task_e_68cf6bde14208332b5b5a3c282a94e0a