### PR TITLE
Expose servo telemetry and surface it in the camera controls

### DIFF
--- a/servers/robot-controller-backend/movement/movement_ws_server.py
+++ b/servers/robot-controller-backend/movement/movement_ws_server.py
@@ -193,6 +193,17 @@ STRAIGHT_ASSIST = StraightDriveAssist(motor)
 
 SPEED_MIN, SPEED_MAX = 0, 4095
 SERVO_MIN, SERVO_MAX = 0, 180
+
+
+def _servo_state_payload(horizontal: int, vertical: int) -> dict:
+    return {
+        "servo": {
+            "horizontal": horizontal,
+            "vertical": vertical,
+            "min": SERVO_MIN,
+            "max": SERVO_MAX,
+        }
+    }
 DEFAULT_SPEED_STEP   = 200
 DEFAULT_SERVO_STEP   = 5
 
@@ -637,7 +648,11 @@ async def handler(ws: WebSocketServerProtocol, request_path: Optional[str] = Non
                     except Exception as e:
                         elog("servo H failed:", repr(e))
                         raise
-                    await send_json(ws, ok("servo-horizontal", angle=current_horizontal_angle))
+                    await send_json(ws, ok(
+                        "servo-horizontal",
+                        angle=current_horizontal_angle,
+                        **_servo_state_payload(current_horizontal_angle, current_vertical_angle),
+                    ))
 
                 elif cmd == "servo-vertical":
                     delta = int(data.get("angle", 0))
@@ -647,7 +662,11 @@ async def handler(ws: WebSocketServerProtocol, request_path: Optional[str] = Non
                     except Exception as e:
                         elog("servo V failed:", repr(e))
                         raise
-                    await send_json(ws, ok("servo-vertical", angle=current_vertical_angle))
+                    await send_json(ws, ok(
+                        "servo-vertical",
+                        angle=current_vertical_angle,
+                        **_servo_state_payload(current_horizontal_angle, current_vertical_angle),
+                    ))
 
                 elif cmd == "set-servo-position":
                     h = data.get("horizontal", None)
@@ -661,9 +680,12 @@ async def handler(ws: WebSocketServerProtocol, request_path: Optional[str] = Non
                         if v is not None:
                             current_vertical_angle = clamp(int(v), SERVO_MIN, SERVO_MAX)
                             servo.setServoPwm("vertical", current_vertical_angle)
-                        await send_json(ws, ok("set-servo-position",
-                                               horizontal=current_horizontal_angle,
-                                               vertical=current_vertical_angle))
+                        await send_json(ws, ok(
+                            "set-servo-position",
+                            horizontal=current_horizontal_angle,
+                            vertical=current_vertical_angle,
+                            **_servo_state_payload(current_horizontal_angle, current_vertical_angle),
+                        ))
 
                 elif cmd == "reset-servo":
                     # Use current positions as the new "center" positions
@@ -672,30 +694,49 @@ async def handler(ws: WebSocketServerProtocol, request_path: Optional[str] = Non
                     current_vertical_angle = 90
                     servo.setServoPwm("horizontal", current_horizontal_angle)
                     servo.setServoPwm("vertical", current_vertical_angle)
-                    await send_json(ws, ok("reset-servo",
-                                           horizontal=current_horizontal_angle,
-                                           vertical=current_vertical_angle))
+                    await send_json(ws, ok(
+                        "reset-servo",
+                        horizontal=current_horizontal_angle,
+                        vertical=current_vertical_angle,
+                        **_servo_state_payload(current_horizontal_angle, current_vertical_angle),
+                    ))
 
                 # camera nudge aliases
                 elif cmd == "camera-servo-left":
                     current_horizontal_angle = clamp(current_horizontal_angle - DEFAULT_SERVO_STEP, SERVO_MIN, SERVO_MAX)
                     servo.setServoPwm("horizontal", current_horizontal_angle)
-                    await send_json(ws, ok("camera-servo-left", angle=current_horizontal_angle))
+                    await send_json(ws, ok(
+                        "camera-servo-left",
+                        angle=current_horizontal_angle,
+                        **_servo_state_payload(current_horizontal_angle, current_vertical_angle),
+                    ))
 
                 elif cmd == "camera-servo-right":
                     current_horizontal_angle = clamp(current_horizontal_angle + DEFAULT_SERVO_STEP, SERVO_MIN, SERVO_MAX)
                     servo.setServoPwm("horizontal", current_horizontal_angle)
-                    await send_json(ws, ok("camera-servo-right", angle=current_horizontal_angle))
+                    await send_json(ws, ok(
+                        "camera-servo-right",
+                        angle=current_horizontal_angle,
+                        **_servo_state_payload(current_horizontal_angle, current_vertical_angle),
+                    ))
 
                 elif cmd == "camera-servo-up":
                     current_vertical_angle = clamp(current_vertical_angle + DEFAULT_SERVO_STEP, SERVO_MIN, SERVO_MAX)
                     servo.setServoPwm("vertical", current_vertical_angle)
-                    await send_json(ws, ok("camera-servo-up", angle=current_vertical_angle))
+                    await send_json(ws, ok(
+                        "camera-servo-up",
+                        angle=current_vertical_angle,
+                        **_servo_state_payload(current_horizontal_angle, current_vertical_angle),
+                    ))
 
                 elif cmd == "camera-servo-down":
                     current_vertical_angle = clamp(current_vertical_angle - DEFAULT_SERVO_STEP, SERVO_MIN, SERVO_MAX)
                     servo.setServoPwm("vertical", current_vertical_angle)
-                    await send_json(ws, ok("camera-servo-down", angle=current_vertical_angle))
+                    await send_json(ws, ok(
+                        "camera-servo-down",
+                        angle=current_vertical_angle,
+                        **_servo_state_payload(current_horizontal_angle, current_vertical_angle),
+                    ))
 
                 # -------- STATUS --------
                 elif cmd == "status":
@@ -705,6 +746,8 @@ async def handler(ws: WebSocketServerProtocol, request_path: Optional[str] = Non
                         "servo": {
                             "horizontal": current_horizontal_angle,
                             "vertical": current_vertical_angle,
+                            "min": SERVO_MIN,
+                            "max": SERVO_MAX,
                         },
                         "buzzer": buzzer_on_state,
                         "autonomy": AUTONOMY.status(),

--- a/ui/robot-controller-ui/src/components/control/ServoTelemetryPanel.tsx
+++ b/ui/robot-controller-ui/src/components/control/ServoTelemetryPanel.tsx
@@ -1,0 +1,96 @@
+/*
+# File: /Omega-Code/ui/robot-controller-ui/src/components/control/ServoTelemetryPanel.tsx
+# Summary:
+Live pan/tilt telemetry card that displays the latest servo angles and operating
+range next to the camera controls. Pulls data from CommandContext (WebSocket
+acks + status snapshots) and offers a manual refresh button that re-issues the
+`status` command when available.
+*/
+
+import React from 'react';
+import { useCommand } from '@/context/CommandContext';
+import { statusColor } from '@/constants/status';
+
+type Source = 'ack' | 'status' | null;
+
+const sourceLabel: Record<Exclude<Source, null>, string> = {
+  ack: 'Ack',
+  status: 'Status',
+};
+
+const formatAngle = (value: number | null): string =>
+  value == null ? '—' : `${Math.round(value)}°`;
+
+const formatRange = (min: number | null, max: number | null): string => {
+  if (min == null || max == null) return '—';
+  return `${Math.round(min)}° – ${Math.round(max)}°`;
+};
+
+const statusLabel = (status: 'connecting' | 'connected' | 'disconnected') =>
+  status === 'connected' ? 'Live' : status === 'connecting' ? 'Connecting' : 'Offline';
+
+export default function ServoTelemetryPanel() {
+  const { servoTelemetry, status, requestStatus } = useCommand();
+  const { horizontal, vertical, min, max, updatedAt, source } = servoTelemetry;
+
+  const updatedText = React.useMemo(() => {
+    if (!updatedAt) return 'Waiting for telemetry…';
+    const time = new Date(updatedAt).toLocaleTimeString();
+    const via = source ? ` via ${sourceLabel[source]}` : '';
+    return `Updated ${time}${via}`;
+  }, [updatedAt, source]);
+
+  const canRefresh = status === 'connected';
+
+  const handleRefresh = React.useCallback(() => {
+    if (!canRefresh) return;
+    requestStatus('servo refresh');
+  }, [canRefresh, requestStatus]);
+
+  return (
+    <div
+      className="mt-4 w-60 rounded-xl border border-white/10 bg-zinc-900/75 px-4 py-3 text-sm text-zinc-100 shadow"
+      aria-live="polite"
+    >
+      <div className="flex items-center justify-between text-xs font-semibold uppercase tracking-wide text-zinc-400">
+        <span>Servo Telemetry</span>
+        <span className="flex items-center gap-1 text-[0.7rem] normal-case text-zinc-300">
+          <span
+            className={`h-2.5 w-2.5 rounded-full ${statusColor[status]}`}
+            aria-hidden
+          />
+          {statusLabel(status)}
+        </span>
+      </div>
+
+      <dl className="mt-3 space-y-2">
+        <div className="flex items-center justify-between">
+          <dt className="text-zinc-400">Pan</dt>
+          <dd className="font-semibold text-base text-white">{formatAngle(horizontal)}</dd>
+        </div>
+        <div className="flex items-center justify-between">
+          <dt className="text-zinc-400">Tilt</dt>
+          <dd className="font-semibold text-base text-white">{formatAngle(vertical)}</dd>
+        </div>
+        <div className="flex items-center justify-between text-xs text-zinc-400">
+          <dt>Range</dt>
+          <dd className="font-medium text-zinc-200">{formatRange(min, max)}</dd>
+        </div>
+      </dl>
+
+      <div className="mt-3 flex items-center justify-between text-[0.7rem] text-zinc-400">
+        <span>{updatedText}</span>
+        <button
+          type="button"
+          onClick={handleRefresh}
+          disabled={!canRefresh}
+          className={`rounded-md px-2 py-1 font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50 ${
+            canRefresh ? 'bg-emerald-600 text-white hover:bg-emerald-500' : 'bg-zinc-700 text-zinc-300'
+          }`}
+        >
+          Refresh
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/ui/robot-controller-ui/src/pages/index.tsx
+++ b/ui/robot-controller-ui/src/pages/index.tsx
@@ -25,6 +25,7 @@ import CommandLog from '../components/CommandLog';
 import SensorDashboard from '../components/sensors/SensorDashboard';
 import CarControlPanel from '../components/control/CarControlPanel';
 import CameraControlPanel from '../components/control/CameraControlPanel';
+import ServoTelemetryPanel from '../components/control/ServoTelemetryPanel';
 import AutonomyPanel from '../components/control/AutonomyModal';
 import { useCommand } from '../context/CommandContext';
 import { COMMAND } from '../control_definitions';
@@ -367,8 +368,9 @@ export default function Home() {
             />
           </div>
 
-          <div className="flex-shrink-0">
+          <div className="flex-shrink-0 flex flex-col items-center">
             <CameraControlPanel />
+            <ServoTelemetryPanel />
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- extend the movement WebSocket acknowledgements and status snapshots to include servo position/range metadata
- capture the live servo telemetry in the CommandContext and auto-request a snapshot on connect
- add a ServoTelemetryPanel beside the camera controls to display pan/tilt angles, range, and manual refresh

## Testing
- python -m compileall servers/robot-controller-backend/movement/movement_ws_server.py
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cf8227fd3483328cb0853d11d0f801