### PR TITLE
Simplify PID controller for single-axis motor drive

### DIFF
--- a/servers/robot-controller-backend/controllers/__init__.py
+++ b/servers/robot-controller-backend/controllers/__init__.py
@@ -1,2 +1,6 @@
 """Controller package."""
 
+from .advanced_pid import AdvancedPIDController, PIDConfig
+
+__all__ = ["AdvancedPIDController", "PIDConfig"]
+

--- a/servers/robot-controller-backend/controllers/advanced_pid.py
+++ b/servers/robot-controller-backend/controllers/advanced_pid.py
@@ -1,0 +1,101 @@
+"""Advanced PID controller tailored for the rover's throttle motor."""
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from typing import Optional, Tuple
+import math
+
+
+@dataclass
+class PIDConfig:
+    """Configuration values for the throttle controller."""
+
+    kp: float
+    ki: float
+    kd: float
+    kf: float = 0.0
+    setpoint: float = 0.0
+    output_limits: Tuple[float, float] = (-1.0, 1.0)
+    integral_limits: Tuple[float, float] = (-1.0, 1.0)
+    derivative_filter: float = 0.2
+    integral_separation: float = math.inf
+    anti_windup: bool = True
+
+
+@dataclass
+class PIDState:
+    """Holds the evolving controller state for introspection and testing."""
+
+    integral: float = 0.0
+    filtered_derivative: float = 0.0
+    last_error: float = 0.0
+    last_measurement: float = 0.0
+    last_output: float = 0.0
+
+
+def _clamp(value: float, limits: Tuple[float, float]) -> float:
+    lower, upper = limits
+    return max(lower, min(upper, value))
+
+
+class AdvancedPIDController:
+    """PID controller with anti-windup, derivative filtering and feed-forward."""
+
+    def __init__(self, config: PIDConfig) -> None:
+        self.config = config
+        self._state = PIDState()
+        self._setpoint = config.setpoint
+
+    def reset(self) -> None:
+        self._state = PIDState()
+
+    def set_setpoint(self, setpoint: float) -> None:
+        self._setpoint = setpoint
+
+    def update(self, measurement: float, dt: float, *, feedforward: Optional[float] = None) -> float:
+        if dt <= 0.0:
+            raise ValueError("dt must be positive")
+
+        error = self._setpoint - measurement
+        proportional = self.config.kp * error
+
+        if abs(error) <= self.config.integral_separation:
+            new_integral = self._state.integral + error * dt
+            new_integral = _clamp(new_integral, self.config.integral_limits)
+        else:
+            new_integral = self._state.integral
+
+        derivative = 0.0
+        if dt > 0:
+            derivative = (measurement - self._state.last_measurement) / dt
+        alpha = _clamp(self.config.derivative_filter, (0.0, 0.999))
+        filtered_derivative = alpha * self._state.filtered_derivative + (1.0 - alpha) * derivative
+        derivative_term = -self.config.kd * filtered_derivative
+
+        ff_term = 0.0
+        if feedforward is not None:
+            ff_term = self.config.kf * feedforward
+        elif self.config.kf:
+            ff_term = self.config.kf * self._setpoint
+
+        output = proportional + self.config.ki * new_integral + derivative_term + ff_term
+        clamped_output = _clamp(output, self.config.output_limits)
+
+        if self.config.anti_windup and clamped_output != output:
+            new_integral = self._state.integral
+            output = proportional + self.config.ki * new_integral + derivative_term + ff_term
+            clamped_output = _clamp(output, self.config.output_limits)
+
+        self._state = PIDState(
+            integral=new_integral,
+            filtered_derivative=filtered_derivative,
+            last_error=error,
+            last_measurement=measurement,
+            last_output=clamped_output,
+        )
+        return clamped_output
+
+    def get_state(self) -> PIDState:
+        return replace(self._state)
+
+

--- a/servers/robot-controller-backend/hardware/sensor_fusion.py
+++ b/servers/robot-controller-backend/hardware/sensor_fusion.py
@@ -1,0 +1,284 @@
+"""Sensor fusion utilities for combining motion hints and ultrasonic data.
+
+The module provides a light-weight Kalman filter tailored for the rover's
+primary localisation problem: estimating forward displacement using available
+motion cues and the ultrasonic range finder as the absolute distance sensor.
+When IMU acceleration data is available it can be supplied to the manager, but
+the fusion pipeline also works when only ultrasonic measurements are present.
+In that case the filter relies on the constant-acceleration model to propagate
+state between measurements which still provides a smoothed position estimate
+and an approximate velocity derived from the measurement history.
+
+The public entry point is :class:`SensorFusionManager` which keeps track of the
+latest fused state, measurement quality and residuals.  The helper class
+:class:`KalmanFilter1D` performs the actual predict/update maths.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Deque, Dict, Optional
+from collections import deque
+import math
+
+import numpy as np
+
+
+@dataclass
+class KalmanConfig:
+    """Configuration for the 1D Kalman filter used by the rover.
+
+    Parameters
+    ----------
+    dt:
+        Default integration period in seconds.  When sensor timestamps are
+        provided the filter adapts the timestep dynamically.
+    process_variance:
+        Variance of the motion model noise.  Higher values make the prediction
+        more responsive to acceleration updates.
+    measurement_variance:
+        Variance associated with the ultrasonic measurements.
+    acceleration_variance:
+        Variance applied to the IMU acceleration control input.
+    min_quality:
+        Quality threshold (0-1) below which ultrasonic measurements are ignored.
+    history_size:
+        Number of fused states stored for introspection and debugging.
+    """
+
+    dt: float = 0.05
+    process_variance: float = 1e-3
+    measurement_variance: float = 0.05
+    acceleration_variance: float = 0.1
+    min_quality: float = 0.2
+    history_size: int = 120
+
+
+@dataclass
+class FusedState:
+    """Container describing the fused pose estimate."""
+
+    position: float
+    velocity: float
+    covariance: np.ndarray
+    residual: float
+    timestamp: float
+    quality: float
+
+
+class KalmanFilter1D:
+    """Constant-acceleration Kalman filter for 1D position estimates."""
+
+    def __init__(self, config: KalmanConfig) -> None:
+        self.config = config
+        self.state = np.zeros((2, 1), dtype=float)  # [position, velocity]
+        self.covariance = np.eye(2, dtype=float)
+        self._dt = config.dt
+        self._residual = 0.0
+
+    @staticmethod
+    def _system_matrices(dt: float, process_variance: float) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+        """Return state transition, control and process noise matrices."""
+
+        f = np.array([[1.0, dt], [0.0, 1.0]], dtype=float)
+        b = np.array([[0.5 * dt ** 2], [dt]], dtype=float)
+        q = np.array(
+            [
+                [dt ** 4 / 4.0, dt ** 3 / 2.0],
+                [dt ** 3 / 2.0, dt ** 2],
+            ],
+            dtype=float,
+        ) * process_variance
+        return f, b, q
+
+    def predict(self, acceleration: float = 0.0, *, dt: Optional[float] = None) -> None:
+        """Propagate the state using the provided acceleration."""
+
+        step = float(dt) if dt is not None and dt > 0.0 else self.config.dt
+        f, b, q = self._system_matrices(step, self.config.process_variance)
+
+        control = np.array([[acceleration]], dtype=float)
+        self.state = f @ self.state + b @ control
+        self.covariance = f @ self.covariance @ f.T + q
+        self._dt = step
+
+    def update(self, distance: float, *, variance: Optional[float] = None) -> None:
+        """Correct the prediction with an ultrasonic measurement."""
+
+        h = np.array([[1.0, 0.0]], dtype=float)
+        r = float(variance) if variance is not None else self.config.measurement_variance
+        r_matrix = np.array([[max(r, 1e-9)]], dtype=float)
+
+        innovation = distance - float((h @ self.state)[0, 0])
+        innovation_covariance = float((h @ self.covariance @ h.T + r_matrix)[0, 0])
+        kalman_gain = (self.covariance @ h.T) / innovation_covariance
+
+        self.state = self.state + kalman_gain * innovation
+        identity = np.eye(2, dtype=float)
+        self.covariance = (identity - kalman_gain @ h) @ self.covariance
+        self._residual = innovation
+
+    @property
+    def residual(self) -> float:
+        return float(self._residual)
+
+    @property
+    def position(self) -> float:
+        return float(self.state[0, 0])
+
+    @property
+    def velocity(self) -> float:
+        return float(self.state[1, 0])
+
+
+class SensorFusionManager:
+    """High level helper blending motion hints and ultrasonic readings."""
+
+    def __init__(self, config: Optional[KalmanConfig] = None) -> None:
+        self.config = config or KalmanConfig()
+        self.filter = KalmanFilter1D(self.config)
+        self._history: Deque[FusedState] = deque(maxlen=self.config.history_size)
+        self._last_timestamp: Optional[float] = None
+        self._confidence = 0.0
+        self._missed_ultrasonic = 0
+        self._pending_acceleration = 0.0
+
+    def reset(self) -> None:
+        """Reset the fusion filter and internal caches."""
+
+        self.filter = KalmanFilter1D(self.config)
+        self._history.clear()
+        self._last_timestamp = None
+        self._confidence = 0.0
+        self._missed_ultrasonic = 0
+        self._pending_acceleration = 0.0
+
+    def _compute_dt(self, timestamp: Optional[float]) -> Optional[float]:
+        """Determine the integration step based on the provided timestamp."""
+
+        if timestamp is None:
+            return self.config.dt
+
+        if self._last_timestamp is None:
+            return self.config.dt
+
+        delta = timestamp - self._last_timestamp
+        if delta <= 1e-6:
+            return None
+
+        return max(delta, 1e-3)
+
+    def _advance_time(self, timestamp: Optional[float], dt: Optional[float]) -> None:
+        """Update the cached timestamp after a prediction step."""
+
+        if timestamp is not None:
+            self._last_timestamp = timestamp
+        elif dt is not None:
+            base = self._last_timestamp or 0.0
+            self._last_timestamp = base + dt
+
+    def ingest_imu(self, *, acceleration: float, timestamp: Optional[float] = None, variance: Optional[float] = None) -> None:
+        """Process a new IMU reading.
+
+        Parameters
+        ----------
+        acceleration:
+            Linear acceleration along the rover's forward axis in metres per
+            second squared.
+        timestamp:
+            Optional monotonic timestamp for the reading.  When supplied the
+            integration step is derived from the delta compared to the previous
+            update.
+        variance:
+            Optional variance of the acceleration.  If provided it is blended
+            with the configured process noise.
+        """
+
+        dt = self._compute_dt(timestamp)
+
+        if dt is not None:
+            if variance is not None:
+                original_variance = self.config.process_variance
+                self.config.process_variance = max(variance, 1e-6)
+                self.filter.predict(acceleration, dt=dt)
+                self.config.process_variance = original_variance
+            else:
+                self.filter.predict(acceleration, dt=dt)
+            self._advance_time(timestamp, dt)
+
+        self._pending_acceleration = acceleration
+
+        self._update_confidence()
+        self._record_state(timestamp)
+
+    def ingest_ultrasonic(
+        self,
+        *,
+        distance: float,
+        quality: float = 1.0,
+        timestamp: Optional[float] = None,
+        variance: Optional[float] = None,
+    ) -> None:
+        """Process a new ultrasonic reading."""
+
+        dt = self._compute_dt(timestamp)
+        if dt is not None:
+            self.filter.predict(self._pending_acceleration, dt=dt)
+            self._advance_time(timestamp, dt)
+
+        if quality < self.config.min_quality:
+            self._missed_ultrasonic += 1
+            self._update_confidence()
+            self._record_state(timestamp)
+            return
+
+        self._missed_ultrasonic = 0
+        self.filter.update(distance, variance=variance)
+
+        if timestamp is not None:
+            self._last_timestamp = timestamp
+
+        self._update_confidence(boost=True)
+        self._record_state(timestamp)
+
+    def _update_confidence(self, *, boost: bool = False) -> None:
+        """Update the confidence metric based on covariance and measurement health."""
+
+        position_variance = float(self.filter.covariance[0, 0])
+        covariance_score = 1.0 / (1.0 + position_variance)
+        covariance_score = max(0.0, min(1.0, covariance_score))
+
+        if self._missed_ultrasonic:
+            decay = math.exp(-0.5 * self._missed_ultrasonic)
+            covariance_score *= decay
+
+        if boost:
+            covariance_score = min(1.0, covariance_score + 0.1)
+
+        self._confidence = covariance_score
+
+    def _record_state(self, timestamp: Optional[float]) -> None:
+        state = FusedState(
+            position=self.filter.position,
+            velocity=self.filter.velocity,
+            covariance=self.filter.covariance.copy(),
+            residual=self.filter.residual,
+            timestamp=timestamp if timestamp is not None else (self._last_timestamp or 0.0),
+            quality=self._confidence,
+        )
+        self._history.append(state)
+
+    def get_state(self) -> Dict[str, float | np.ndarray]:
+        """Return the most recent fused state as a dictionary."""
+
+        return {
+            "position": self.filter.position,
+            "velocity": self.filter.velocity,
+            "covariance": self.filter.covariance.copy(),
+            "residual": self.filter.residual,
+            "quality": self._confidence,
+        }
+
+    def history(self) -> Deque[FusedState]:
+        """Return a reference to the fused state history for inspection."""
+
+        return self._history

--- a/servers/robot-controller-backend/tests/unit/hardware/__init__.py
+++ b/servers/robot-controller-backend/tests/unit/hardware/__init__.py
@@ -1,0 +1,1 @@
+"""Hardware unit tests."""

--- a/servers/robot-controller-backend/tests/unit/hardware/test_advanced_pid.py
+++ b/servers/robot-controller-backend/tests/unit/hardware/test_advanced_pid.py
@@ -1,0 +1,80 @@
+"""Unit tests exercising the advanced PID controllers."""
+from __future__ import annotations
+
+import math
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[3]
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))
+
+from controllers.advanced_pid import AdvancedPIDController, PIDConfig
+
+
+def test_pid_controller_converges_to_setpoint() -> None:
+    controller = AdvancedPIDController(
+        PIDConfig(kp=1.4, ki=0.8, kd=0.2, output_limits=(-10.0, 10.0))
+    )
+    controller.set_setpoint(5.0)
+
+    measurement = 0.0
+    dt = 0.05
+    for _ in range(200):
+        output = controller.update(measurement, dt)
+        measurement += output * dt * 0.3
+
+    state = controller.get_state()
+    assert math.isclose(measurement, 5.0, rel_tol=0.05)
+    assert abs(state.last_error) < 0.3
+    assert state.last_output <= 10.0
+
+
+def test_pid_respects_output_limits_and_anti_windup() -> None:
+    controller = AdvancedPIDController(
+        PIDConfig(kp=0.5, ki=2.0, kd=0.0, output_limits=(-1.0, 1.0))
+    )
+    controller.set_setpoint(100.0)
+
+    measurement = 0.0
+    dt = 0.1
+    for _ in range(50):
+        controller.update(measurement, dt)
+
+    state = controller.get_state()
+    assert abs(state.integral) < controller.config.integral_limits[1]
+    assert math.isclose(state.last_output, 1.0, rel_tol=1e-6)
+
+
+def test_pid_derivative_filter_smooths_noise() -> None:
+    noisy_controller = AdvancedPIDController(
+        PIDConfig(kp=0.0, ki=0.0, kd=1.0, derivative_filter=0.0, output_limits=(-5.0, 5.0))
+    )
+    filtered_controller = AdvancedPIDController(
+        PIDConfig(kp=0.0, ki=0.0, kd=1.0, derivative_filter=0.8, output_limits=(-5.0, 5.0))
+    )
+
+    measurements = [0.0, 1.0, -1.0, 1.0, -1.0]
+    dt = 0.05
+
+    noisy_outputs = [noisy_controller.update(value, dt) for value in measurements]
+    filtered_outputs = [filtered_controller.update(value, dt) for value in measurements]
+
+    assert max(abs(val) for val in filtered_outputs) < max(abs(val) for val in noisy_outputs)
+
+
+def test_feedforward_defaults_to_setpoint_when_enabled() -> None:
+    controller = AdvancedPIDController(
+        PIDConfig(kp=0.0, ki=0.0, kd=0.0, kf=0.5, setpoint=3.0, output_limits=(-10.0, 10.0))
+    )
+
+    output = controller.update(0.0, dt=0.1)
+    assert math.isclose(output, 1.5, rel_tol=1e-6)
+
+
+def test_pid_requires_positive_dt() -> None:
+    controller = AdvancedPIDController(PIDConfig(kp=1.0, ki=0.0, kd=0.0))
+    with pytest.raises(ValueError):
+        controller.update(0.0, 0.0)

--- a/servers/robot-controller-backend/tests/unit/hardware/test_sensor_fusion.py
+++ b/servers/robot-controller-backend/tests/unit/hardware/test_sensor_fusion.py
@@ -1,0 +1,78 @@
+"""Tests for the sensor fusion module."""
+from __future__ import annotations
+
+import math
+import sys
+from pathlib import Path
+
+import numpy as np
+
+ROOT = Path(__file__).resolve().parents[3]
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))
+
+from hardware.sensor_fusion import KalmanConfig, SensorFusionManager
+
+
+def test_sensor_fusion_converges_on_constant_acceleration() -> None:
+    config = KalmanConfig(dt=0.1, process_variance=5e-3, measurement_variance=0.02)
+    fusion = SensorFusionManager(config)
+
+    acceleration = 0.8
+    time = 0.0
+    for _ in range(20):
+        time += config.dt
+        distance = 0.5 * acceleration * time ** 2
+        fusion.ingest_imu(acceleration=acceleration, timestamp=time)
+        fusion.ingest_ultrasonic(distance=distance, quality=1.0, timestamp=time)
+
+    state = fusion.get_state()
+    assert math.isclose(state["position"], distance, rel_tol=0.05)
+    assert math.isclose(state["velocity"], acceleration * time, rel_tol=0.05)
+    assert state["quality"] > 0.7
+
+
+def test_sensor_fusion_rejects_low_quality_measurements() -> None:
+    fusion = SensorFusionManager(KalmanConfig(min_quality=0.5))
+
+    # Seed the filter with a valid measurement
+    fusion.ingest_ultrasonic(distance=1.5, quality=1.0, timestamp=0.0)
+
+    # Attempt to apply a low quality measurement which should be ignored
+    fusion.ingest_ultrasonic(distance=10.0, quality=0.2, timestamp=0.1)
+
+    state = fusion.get_state()
+    assert math.isclose(state["position"], 1.5, rel_tol=0.2)
+    assert state["quality"] < 1.0  # Confidence decays without good readings
+
+
+def test_sensor_fusion_history_tracks_recent_states() -> None:
+    config = KalmanConfig(history_size=5)
+    fusion = SensorFusionManager(config)
+
+    current_time = 0.0
+    for idx in range(7):
+        fusion.ingest_ultrasonic(distance=float(idx), quality=1.0, timestamp=current_time)
+        current_time += config.dt
+
+    history = fusion.history()
+    assert len(history) == config.history_size
+    latest = history[-1]
+    assert math.isclose(latest.position, fusion.get_state()["position"], rel_tol=1e-6)
+    assert isinstance(latest.covariance, np.ndarray)
+
+
+def test_sensor_fusion_ultrasonic_only_sequence_estimates_velocity() -> None:
+    config = KalmanConfig(dt=0.1, process_variance=1e-2, measurement_variance=0.05)
+    fusion = SensorFusionManager(config)
+
+    distances = [2.0, 1.8, 1.6, 1.4, 1.2]
+    current_time = 0.0
+    for distance in distances:
+        fusion.ingest_ultrasonic(distance=distance, quality=1.0, timestamp=current_time)
+        current_time += config.dt
+
+    state = fusion.get_state()
+    assert state["position"] < distances[0]
+    assert state["velocity"] < 0.0
+    assert state["quality"] > 0.3


### PR DESCRIPTION
## Summary
- tailor the advanced PID module for a single throttle axis and remove unused multi-axis orchestration
- rename the PID configuration helper to PIDConfig and update controller exports accordingly
- refresh unit tests to reflect the single-axis controller and cover feed-forward behaviour

## Testing
- pytest servers/robot-controller-backend/tests/unit/hardware -q

------
https://chatgpt.com/codex/tasks/task_e_68d3274f74448332b2fac92f57d2520a